### PR TITLE
feat(sidebar): resizable with per-project width

### DIFF
--- a/PRPs/010--resizable-sidebar.md
+++ b/PRPs/010--resizable-sidebar.md
@@ -1,0 +1,318 @@
+# PRP 010: Resizable Sessions/Files sidebar with per-project width
+
+> **Version:** 1.0
+> **Created:** 2026-04-24
+> **Status:** Draft
+> **Tracks:** [#3](https://github.com/willywg/klaudio-panels/issues/3)
+
+---
+
+## Goal
+
+The Sessions/Files sidebar becomes drag-resizable on its right edge,
+clamped between 200px and 50% of window width. The chosen width is
+persisted **per project** in `localStorage` (key
+`sidebarWidth:<projectPath>`), mirroring the diff panel's
+per-project persistence. Cmd+B collapse behavior is unchanged; on
+expand, the last remembered width for the current project is
+restored.
+
+## Why
+
+- Today the sidebar is hardcoded to `w-[280px]`. Monorepos with long
+  session titles and deep trees feel cramped; flat projects waste
+  horizontal real estate.
+- Per-project (not global) width mirrors the existing
+  `sidebarTab:<projectPath>` and `diffPanelWidth:<projectPath>`
+  patterns — each project already carries its own UX state, width
+  slots in naturally.
+- The underlying drag component (`SplitDivider`) already exists and
+  is reusable with a tiny extension. This is additive, not new
+  surface area.
+
+## What
+
+### Success Criteria
+
+- [ ] A 4px vertical handle on the sidebar's right edge shows a
+      `col-resize` cursor and a hover highlight identical to the
+      diff panel's.
+- [ ] Dragging resizes the sidebar live, clamped to `[200, 0.5 *
+      windowWidth]`.
+- [ ] Width persists to `localStorage["sidebarWidth:<projectPath>"]`
+      on pointer-up (not on every move).
+- [ ] Opening project A at 220px and project B at 360px keeps each
+      at its own width when switching back and forth.
+- [ ] Cmd+B collapses the sidebar to 0; pressing Cmd+B again
+      restores the per-project width (not the 280px default unless
+      no stored width exists).
+- [ ] No regression to the diff panel's existing drag behavior.
+
+### Non-goals
+
+- Dragging the sidebar's left edge (no left-docked analog exists).
+- A "snap back to default" affordance (defer; user can just drag).
+- Animating width changes on restore (instant is fine; matches
+  diff panel today).
+
+---
+
+## All Needed Context
+
+### Project-level references (always relevant)
+
+```yaml
+- file: PROJECT.md
+  why: Blueprint; per-project state convention
+- file: CLAUDE.md
+  why: Decision #12 — sidebar is OpenCode-style collapsible aside.
+       Widening that from a fixed 280 to a range [200, 50%] doesn't
+       break the rule; just makes it user-driven.
+```
+
+### Feature-specific references
+
+```yaml
+- file: src/components/diff-panel/split-pane.tsx
+  why: The <SplitDivider> we will extend. Currently hardcodes
+       right-edge math (rect.right - e.clientX). Add an `edge` prop.
+
+- file: src/context/diff-panel.tsx
+  why: Pattern for per-project width. See `widthFor`, `setWidth`,
+       the Map + widthBump signal, and the DEFAULT_WIDTH constant.
+  lines: 15, 70-71, 211-223
+
+- file: src/lib/diff-panel-prefs.ts
+  why: Direct template for sidebar-prefs width helpers.
+  lines: 21-38
+
+- file: src/App.tsx
+  why: Where <DiffPanel> + <SplitDivider> are mounted today.
+       Sidebar mount site is inside <SidebarPanel> via
+       SidebarProvider — we add the divider as a sibling of
+       <aside> so the drag anchor is in the same flex row.
+  lines: 740-758 (diff panel mount — mirror this)
+```
+
+### Current repo state (relevant files)
+
+```
+src/
+├── App.tsx                              # mount wiring
+├── context/
+│   └── sidebar.tsx                      # add widthFor/setWidth
+├── lib/
+│   └── sidebar-prefs.ts                 # add width helpers
+└── components/
+    ├── sidebar-panel.tsx                # 280 → dynamic width
+    └── diff-panel/
+        └── split-pane.tsx               # add `edge` prop
+```
+
+### Desired changes
+
+```
+src/
+├── context/
+│   └── sidebar.tsx                      [MODIFY — +widthFor/+setWidth]
+├── lib/
+│   └── sidebar-prefs.ts                 [MODIFY — +getSidebarWidth/
+│                                                 +setSidebarWidth]
+└── components/
+    ├── sidebar-panel.tsx                [MODIFY — dynamic width style]
+    ├── diff-panel/
+    │   └── split-pane.tsx               [MODIFY — +edge prop]
+    └── — [no new component files] —
+```
+
+### Known gotchas
+
+```
+- SplitDivider's current clamp naming: `minLeft` / `minRight` is
+  directional and would get confusing with the new edge prop.
+  Rename internally to `minSelf` / `minOther` (self = the panel the
+  divider resizes; other = the panel it shares a row with). Only
+  one external consumer today (App.tsx for diff panel), so the
+  rename is cheap.
+
+- The sidebar mounts inside <aside>. Its parent is the flex row
+  that also holds <section> (terminal area) and the diff panel.
+  `getParentRect` must return THAT row, not the aside. Use the
+  existing `splitContainerRef` that App.tsx already owns for the
+  diff panel — reuse the same ref.
+
+- Cmd+B collapse must not trigger a width write. Width persists
+  only on pointerup. Collapse is a separate concern (already
+  working).
+
+- On mount, if no stored width exists, default to 280 (current
+  hardcoded value) so existing users see zero visual change.
+```
+
+---
+
+## Implementation Blueprint
+
+### Data / types
+
+```typescript
+// src/lib/sidebar-prefs.ts — additions
+const WIDTH_PREFIX = "sidebarWidth:";
+export function getSidebarWidth(projectPath: string): number | null
+export function setSidebarWidth(projectPath: string, px: number): void
+```
+
+```typescript
+// src/context/sidebar.tsx — additions
+const DEFAULT_SIDEBAR_WIDTH = 280;
+// same Map + bump pattern as diff-panel.tsx
+function widthFor(projectPath: string): number
+function setWidth(projectPath: string, px: number): void
+```
+
+```typescript
+// src/components/diff-panel/split-pane.tsx — additions
+type Props = {
+  edge?: "left" | "right";   // default "right" (back-compat)
+  width: number;
+  onResize: (next: number) => void;
+  onResizeEnd: (final: number) => void;
+  getParentRect: () => DOMRect;
+  minSelf?: number;           // renamed from minRight
+  minOther?: number;          // renamed from minLeft
+}
+```
+
+### Tasks (in execution order)
+
+```yaml
+Task 1: sidebar-prefs.ts — add width helpers
+  - MIRROR: diff-panel-prefs.ts
+  - KEY: "sidebarWidth:" prefix
+
+Task 2: sidebar.tsx context — expose widthFor/setWidth
+  - MIRROR: diff-panel.tsx context (Map + widthBump signal)
+  - DEFAULT: 280
+
+Task 3: split-pane.tsx — extract edge-aware math
+  - ADD: `edge` prop ("left" | "right"), default "right"
+  - RENAME: minLeft/minRight → minOther/minSelf
+  - FLIP: if edge="left", proposed = e.clientX - rect.left;
+          else proposed = rect.right - e.clientX
+  - UPDATE: sole caller (App.tsx line ~743) to use new prop names
+
+Task 4: sidebar-panel.tsx — dynamic width
+  - REMOVE: w-[280px] from <aside>
+  - ADD: style={{ width: `${sidebar.widthFor(projectPath)}px` }}
+
+Task 5: App.tsx — mount sidebar-edge SplitDivider
+  - INSERT: <SplitDivider edge="left" ...> as immediate sibling
+            after <SidebarPanel> and before the main flex row,
+            only when !sidebar.collapsed()
+  - WIRE: width=sidebar.widthFor(p), onResize=setWidth,
+          getParentRect=splitContainerRef.getBoundingClientRect
+  - MIN: minSelf=200, minOther=360 (same terminal floor the diff
+         panel uses)
+```
+
+### Pseudocode (critical bits)
+
+```tsx
+// split-pane.tsx — edge-aware math
+function onPointerMove(e: PointerEvent) {
+  if (!dragging()) return;
+  const rect = props.getParentRect();
+  const minSelf = props.minSelf ?? 300;
+  const minOther = props.minOther ?? 360;
+  const proposed = props.edge === "left"
+    ? e.clientX - rect.left
+    : rect.right - e.clientX;
+  const maxSelf = rect.width - minOther;
+  const clamped = Math.max(minSelf, Math.min(proposed, maxSelf));
+  props.onResize(clamped);
+}
+```
+
+```tsx
+// App.tsx — sidebar divider placement (sketch)
+<Show when={!sidebar.collapsed() && activeProjectPath()}>
+  {(p) => (
+    <SplitDivider
+      edge="left"
+      width={sidebar.widthFor(p())}
+      onResize={(w) => sidebar.setWidth(p(), w)}
+      onResizeEnd={(w) => sidebar.setWidth(p(), w)}
+      getParentRect={() => splitContainerRef.getBoundingClientRect()}
+      minSelf={200}
+      minOther={360}
+    />
+  )}
+</Show>
+```
+
+---
+
+## Validation Loop
+
+### Level 1: static checks
+
+```bash
+bun run typecheck
+cd src-tauri && cargo check          # no-op — no Rust changes
+cd src-tauri && cargo clippy -- -D warnings
+```
+
+### Level 2: manual integration
+
+```bash
+bun tauri dev
+```
+
+Steps:
+1. Open project A. Drag sidebar right edge to ~220px. Release.
+2. Reload app. Sidebar should still be at 220px.
+3. Open project B. Should open at 280 (default, no stored width).
+   Drag to 360px, release. Reload. B at 360, A still at 220.
+4. Collapse with Cmd+B. Expand with Cmd+B. Width restored.
+5. Try to drag below 200 and above ~50% window — should clamp.
+6. Open diff panel (Cmd+Shift+D or whatever shortcut). Drag its
+   divider. Still works. No regression.
+7. Resize window smaller. (Window-resize-responsiveness is issue
+   #4, not in this PRP — the clamp will cover the clamping but
+   won't auto-shrink to stay proportional. That's fine here.)
+
+---
+
+## Final Checklist
+
+- [ ] `bun run typecheck` clean
+- [ ] `cargo check` + `cargo clippy` clean (no Rust changes expected)
+- [ ] Manual flow above runs without regressions
+- [ ] Sidebar width persists across app restart
+- [ ] Diff panel width still persists and drags correctly (no
+      regression from the SplitDivider refactor)
+- [ ] Cmd+B collapse/expand preserves per-project width
+
+---
+
+## Anti-Patterns to Avoid
+
+- ❌ Don't write width on every pointermove (localStorage spam).
+  Only on pointerup.
+- ❌ Don't create a second DragHandle component — extend the existing
+  `SplitDivider`. One source of truth for drag math.
+- ❌ Don't make width global. Each project has its own UX state
+  already (active tab, diff width); width joins that set.
+- ❌ Don't gate behind a flag. It's additive — nothing to toggle off.
+
+---
+
+## Notes
+
+- Related issue #4 (diff panel / center panel not proportional on
+  window resize) is intentionally out of scope. Both panels will
+  likely share a follow-up "scale-on-window-resize" rule that can
+  live in a single place; doing it here would double the PRP's
+  surface. After this PRP merges, #4 becomes the natural next
+  piece.
+- No Rust changes. Pure frontend.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,7 @@ function Shell() {
   const shellPty = useShellPty();
   const shellPanel = useShellPanel();
   let splitContainerRef!: HTMLDivElement;
+  let sidebarRowRef!: HTMLDivElement;
 
   // Remembered active tab per project. Set BEFORE changing activeProjectPath
   // (inside setActiveProjectPath) so it's never wrong when the switch effect
@@ -658,6 +659,7 @@ function Shell() {
           survives underneath with its xterms intact. */}
       <div class="flex-1 relative min-w-0 min-h-0">
         <div
+          ref={sidebarRowRef}
           class="absolute inset-0 flex min-w-0 min-h-0 overflow-hidden"
           style={{
             visibility: activeProjectPath() ? "visible" : "hidden",
@@ -681,6 +683,26 @@ function Shell() {
                   />
                 }
                 filesContent={<FileTree projectPath={p()} />}
+              />
+            )}
+          </Show>
+          <Show
+            when={
+              activeProjectPath() && !sidebar.collapsed()
+                ? activeProjectPath()
+                : null
+            }
+          >
+            {(p) => (
+              <SplitDivider
+                edge="left"
+                width={sidebar.widthFor(p())}
+                onResize={(w) => sidebar.setWidth(p(), w)}
+                onResizeEnd={(w) => sidebar.setWidth(p(), w)}
+                getParentRect={() => sidebarRowRef.getBoundingClientRect()}
+                minSelf={200}
+                minOther={360}
+                maxFraction={0.5}
               />
             )}
           </Show>

--- a/src/components/diff-panel/split-pane.tsx
+++ b/src/components/diff-panel/split-pane.tsx
@@ -1,24 +1,36 @@
 import { createSignal, onCleanup } from "solid-js";
 
 type Props = {
-  /** Current width of the RIGHT pane in px. Parent owns the signal. */
+  /** Which side of the parent row this divider controls. Determines whether
+   *  the drag distance grows from the left edge (e.g. a left-docked sidebar)
+   *  or from the right edge (e.g. the right-docked diff panel). Defaults to
+   *  "right" for backwards compatibility. */
+  edge?: "left" | "right";
+  /** Current width of the controlled pane in px. Parent owns the signal. */
   width: number;
   /** Called live on pointermove while dragging. Parent should update a
    *  signal, not localStorage. */
   onResize: (nextWidth: number) => void;
   /** Called once on pointerup so parent can persist. */
   onResizeEnd: (finalWidth: number) => void;
-  /** Element whose right edge defines the 100% x-coordinate. Usually the
-   *  SplitPane's parent — we read it on drag to clamp. */
+  /** Element whose edges define the 100% x-coordinate. Usually the row
+   *  that hosts both panes — we read it on drag to clamp. */
   getParentRect: () => DOMRect;
-  minLeft?: number;
-  minRight?: number;
+  /** Minimum width for the pane this divider controls. */
+  minSelf?: number;
+  /** Minimum width reserved for the pane on the OTHER side (typically the
+   *  center/terminal column). */
+  minOther?: number;
+  /** Optional hard ceiling as a fraction of the parent row's width (0–1).
+   *  The effective maxSelf is `min(parent.width * maxFraction,
+   *  parent.width - minOther)`. Leave undefined to only respect `minOther`. */
+  maxFraction?: number;
 };
 
-const DEFAULT_MIN_LEFT = 360;
-const DEFAULT_MIN_RIGHT = 300;
+const DEFAULT_MIN_SELF = 300;
+const DEFAULT_MIN_OTHER = 360;
 
-/** A 4px vertical drag handle for resizing a right-docked panel. Uses
+/** A 4px vertical drag handle for resizing a side-docked panel. Uses
  *  pointer events + setPointerCapture so the drag survives the cursor
  *  leaving the 4px hit area. */
 export function SplitDivider(props: Props) {
@@ -34,11 +46,17 @@ export function SplitDivider(props: Props) {
   function onPointerMove(e: PointerEvent) {
     if (!dragging()) return;
     const rect = props.getParentRect();
-    const minLeft = props.minLeft ?? DEFAULT_MIN_LEFT;
-    const minRight = props.minRight ?? DEFAULT_MIN_RIGHT;
-    const proposed = rect.right - e.clientX;
-    const maxRight = rect.width - minLeft;
-    const clamped = Math.max(minRight, Math.min(proposed, maxRight));
+    const minSelf = props.minSelf ?? DEFAULT_MIN_SELF;
+    const minOther = props.minOther ?? DEFAULT_MIN_OTHER;
+    const edge = props.edge ?? "right";
+    const proposed =
+      edge === "left" ? e.clientX - rect.left : rect.right - e.clientX;
+    const fractionCap =
+      props.maxFraction != null
+        ? rect.width * props.maxFraction
+        : Number.POSITIVE_INFINITY;
+    const maxSelf = Math.min(fractionCap, rect.width - minOther);
+    const clamped = Math.max(minSelf, Math.min(proposed, maxSelf));
     props.onResize(clamped);
   }
 

--- a/src/components/sidebar-panel.tsx
+++ b/src/components/sidebar-panel.tsx
@@ -9,7 +9,8 @@ type Props = {
   filesContent: JSX.Element;
 };
 
-/** 280px aside when expanded; renders nothing when collapsed. Toggle lives in
+/** Drag-resizable aside when expanded; renders nothing when collapsed. Width
+ *  is per-project (default 280px, persisted in localStorage). Toggle lives in
  *  the titlebar via <TitlebarToggle>. Cmd+B toggles from anywhere. Active tab
  *  is per-project. */
 export function SidebarPanel(props: Props) {
@@ -17,7 +18,10 @@ export function SidebarPanel(props: Props) {
 
   return (
     <Show when={!sidebar.collapsed()}>
-      <aside class="w-[280px] shrink-0 border-r border-neutral-800 flex flex-col min-h-0 overflow-hidden bg-neutral-950">
+      <aside
+        class="shrink-0 border-r border-neutral-800 flex flex-col min-h-0 overflow-hidden bg-neutral-950"
+        style={{ width: `${sidebar.widthFor(props.projectPath)}px` }}
+      >
         <div class="px-3 py-2 border-b border-neutral-800">
           <div class="text-[10px] uppercase tracking-wider text-neutral-500">
             Project

--- a/src/context/sidebar.tsx
+++ b/src/context/sidebar.tsx
@@ -7,10 +7,14 @@ import {
 import {
   getActiveTab,
   getCollapsed,
+  getSidebarWidth,
   setActiveTab as persistActiveTab,
   setCollapsed as persistCollapsed,
+  setSidebarWidth as persistSidebarWidth,
   type SidebarTab,
 } from "@/lib/sidebar-prefs";
+
+const DEFAULT_SIDEBAR_WIDTH = 280;
 
 function makeSidebarContext() {
   const [collapsed, setCollapsedSignal] = createSignal<boolean>(getCollapsed());
@@ -19,6 +23,11 @@ function makeSidebarContext() {
   // or blow away any other project's selection.
   const tabByProject = new Map<string, SidebarTab>();
   const [tabBump, setTabBump] = createSignal(0);
+
+  // Per-project width mirrors the diff-panel pattern: read-through cache
+  // over localStorage, a bump signal to re-run reactive reads on write.
+  const widthByProject = new Map<string, number>();
+  const [widthBump, setWidthBump] = createSignal(0);
 
   function activeTab(projectPath: string): SidebarTab {
     if (!tabByProject.has(projectPath)) {
@@ -32,6 +41,21 @@ function makeSidebarContext() {
     tabByProject.set(projectPath, tab);
     persistActiveTab(projectPath, tab);
     setTabBump((k) => k + 1);
+  }
+
+  function widthFor(projectPath: string): number {
+    if (!widthByProject.has(projectPath)) {
+      const stored = getSidebarWidth(projectPath);
+      widthByProject.set(projectPath, stored ?? DEFAULT_SIDEBAR_WIDTH);
+    }
+    void widthBump();
+    return widthByProject.get(projectPath)!;
+  }
+
+  function setWidth(projectPath: string, px: number) {
+    widthByProject.set(projectPath, px);
+    persistSidebarWidth(projectPath, px);
+    setWidthBump((k) => k + 1);
   }
 
   function toggleCollapsed() {
@@ -53,6 +77,8 @@ function makeSidebarContext() {
     collapsed,
     toggleCollapsed,
     setCollapsed,
+    widthFor,
+    setWidth,
   };
 }
 

--- a/src/lib/sidebar-prefs.ts
+++ b/src/lib/sidebar-prefs.ts
@@ -2,6 +2,7 @@ export type SidebarTab = "sessions" | "files";
 
 const COLLAPSED_KEY = "sidebarCollapsed";
 const TAB_KEY_PREFIX = "sidebarTab:";
+const WIDTH_KEY_PREFIX = "sidebarWidth:";
 
 export function getCollapsed(): boolean {
   try {
@@ -32,6 +33,25 @@ export function getActiveTab(projectPath: string): SidebarTab {
 export function setActiveTab(projectPath: string, tab: SidebarTab): void {
   try {
     localStorage.setItem(TAB_KEY_PREFIX + projectPath, tab);
+  } catch {
+    // ignore
+  }
+}
+
+export function getSidebarWidth(projectPath: string): number | null {
+  try {
+    const raw = localStorage.getItem(WIDTH_KEY_PREFIX + projectPath);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setSidebarWidth(projectPath: string, px: number): void {
+  try {
+    localStorage.setItem(WIDTH_KEY_PREFIX + projectPath, String(Math.round(px)));
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary

- Drag handle on the Sessions/Files sidebar right edge — clamped to `[200px, 50% of parent row]` with a 360px floor reserved for the center terminal.
- Width persists **per project** in `localStorage["sidebarWidth:<projectPath>"]`, mirroring the existing `sidebarTab:` and `diffPanelWidth:` patterns. Default is still 280px, so existing users see zero visual change until they grab the handle.
- `<SplitDivider>` (previously diff-panel-only) grew an `edge: "left" | "right"` prop + an optional `maxFraction` ceiling so it can resize either a left- or right-docked panel. Diff panel's existing call site uses defaults → zero regression expected.

Closes #3.

## Notes

- Cmd+B collapse behavior is **unchanged** (still global per `CLAUDE.md` §12). Making collapse per-project came up mid-implementation but was kept out of scope — belongs in its own issue + CLAUDE.md update.
- Issue #4 (diff panel / center panel not proportional on window resize) is intentionally NOT addressed here. The clamp on this PR keeps the sidebar from eating the terminal, but there is no auto-shrink on window resize yet. Natural follow-up PR.
- Full design notes in [`PRPs/010--resizable-sidebar.md`](./PRPs/010--resizable-sidebar.md).

## Test plan

Static checks pass locally (typecheck + `cargo check` + `cargo clippy -- -D warnings`). UI smoke test needed:

- [ ] Drag sidebar right edge — resizes live, cursor shows `ew-resize`, handle highlights indigo while dragging
- [ ] Release drag → width persists; reload app → same width restored
- [ ] Open project A at 220px and project B at 360px → each project keeps its own width when switching back and forth
- [ ] Drag tries to go below 200 → clamps at 200
- [ ] Drag tries to go above 50% of window → clamps at 50%
- [ ] Cmd+B collapses, Cmd+B expands → last per-project width restored (not default 280)
- [ ] Diff panel (right-docked) still drags and persists correctly — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)