### PR TITLE
fix(layout): proportional panel resize on window shrink

### DIFF
--- a/PRPs/011--proportional-panel-resize.md
+++ b/PRPs/011--proportional-panel-resize.md
@@ -1,0 +1,416 @@
+# PRP 011: Proportional panel resize on window shrink
+
+> **Version:** 1.0
+> **Created:** 2026-04-24
+> **Status:** Draft
+> **Tracks:** [#4](https://github.com/willywg/klaudio-panels/issues/4)
+> **Builds on:** [PRP 010](./010--resizable-sidebar.md)
+
+---
+
+## Goal
+
+When the app window is resized smaller, the side-docked panels
+(sidebar from PRP 010, diff panel) stop holding their absolute
+pixel width and instead clamp to the new parent-row width while
+preserving the user's stored preference. When the window grows
+back, the displayed widths return to the stored values. The user's
+choice is never silently overwritten.
+
+## Why
+
+- Reported in [#4](https://github.com/willywg/klaudio-panels/issues/4): on a narrower window the diff panel
+  keeps its full ~640px and the center terminal is squeezed to the
+  point of being unusable. PRP 010 just added the same issue for
+  the sidebar.
+- The current `SplitDivider` clamps only during drag. Once the
+  drag ends, the stored width can exceed what the current window
+  allows if the window shrinks later.
+- Users expect OS-native window-resize behavior: panels give back
+  space proportionally until they hit a minimum, then the center
+  starts to shrink. We do the first half but not the second.
+
+## What
+
+A read-side clamp: each panel's rendered width is
+`min(stored, maxEffective)`, where `maxEffective` is derived from
+the current parent-row width. The stored value (in `localStorage`)
+is never mutated by window resizes — only by explicit user drags.
+
+### Success Criteria
+
+- [ ] Open a project with both sidebar (at e.g. 360px) and diff
+      panel (at 640px). Shrink the window. The panels give up
+      width proportionally; the center terminal keeps ≥360px until
+      both panels hit their mins.
+- [ ] Grow the window back. The panels restore to their stored
+      widths (360 / 640) without the user doing anything.
+- [ ] `localStorage["sidebarWidth:<project>"]` and
+      `["diffPanelWidth:<project>"]` are unchanged across the
+      shrink/grow cycle.
+- [ ] Dragging a panel in a narrow window works: the drag clamp
+      (already in `SplitDivider`) respects the same maxEffective.
+- [ ] When only one panel is open, it alone gets the remaining
+      space up to its 50% cap.
+- [ ] Combined panel widths can never push the center below its
+      minimum (360px).
+
+### Non-goals
+
+- Animating the shrink (instant is fine; OS native panels are
+  instant).
+- Proportional *growth* beyond stored values (that would require a
+  "fill available space" mode — out of scope).
+
+### Additional rules (confirmed with maintainer)
+
+1. **Absolute caps per panel**, independent of `maxFraction`:
+   - `SIDEBAR_MAX = 500`
+   - `DIFF_MAX = 800`
+   On ultrawide monitors this forces the leftover space into the
+   center column (which is the user's priority).
+
+2. **Non-destructive auto-hide of the diff panel** when the window
+   is too narrow to host both panels + a usable center. Threshold:
+   `rowWidth < SIDEBAR_MIN + DIFF_MIN + CENTER_MIN` (= 860 with
+   sidebar visible) or `< DIFF_MIN + CENTER_MIN` (= 660 with
+   sidebar collapsed). When triggered, the diff panel is not
+   rendered, but `diffPanelOpen:<path>` in localStorage is NOT
+   touched — widening the window makes it reappear automatically.
+
+3. **No debounce on `ResizeObserver`.** The browser already
+   schedules RO callbacks against rAF.
+
+---
+
+## All Needed Context
+
+### Project-level references
+
+```yaml
+- file: PRPs/010--resizable-sidebar.md
+  why: Immediately-preceding PRP. Establishes per-project width +
+       SplitDivider.edge + the 200/360 clamp values we're reusing.
+- file: CLAUDE.md
+  why: Rules #7 + #12 on panel layout. Nothing new contradicted.
+```
+
+### Feature-specific references
+
+```yaml
+- file: src/components/diff-panel/split-pane.tsx
+  why: Drag-time clamp already uses `rect.width - minOther` plus
+       the `maxFraction` cap from PRP 010. We extend that math to
+       the render path.
+
+- file: src/context/sidebar.tsx
+  why: Pattern to expose effective-width read.
+  lines: widthFor ~end of file
+
+- file: src/context/diff-panel.tsx
+  why: Same pattern, different context.
+  lines: 211-223 (widthFor/setWidth)
+
+- file: src/App.tsx
+  why: Central mount point. The parent row (`sidebarRowRef`) is
+       where we attach a ResizeObserver and derive rowWidth.
+  lines: 661 (sidebarRowRef), 693 (splitContainerRef), 697-710
+         (sidebar SplitDivider), 762-780 (diff SplitDivider)
+```
+
+### Desired changes (files to modify)
+
+```
+src/
+├── lib/
+│   └── panel-layout.ts       [NEW — pure helpers + shared constants,
+│                               computes sidebar + diff effective widths
+│                               TOGETHER so the center is guaranteed
+│                               its 360px floor]
+├── components/
+│   ├── sidebar-panel.tsx     [accept width via prop instead of
+│   │                           reading context directly]
+│   └── diff-panel/
+│       └── split-pane.tsx    [no change — already handles
+│                               maxFraction/minOther]
+└── App.tsx                   [+ResizeObserver on sidebarRowRef,
+                               +rowWidth signal, createMemo wrapping
+                               computePanelLayout, wire effective
+                               widths into renders + dividers]
+```
+
+### Why a joint helper (not per-context methods)
+
+Initial draft put `effectiveWidthFor` on each context. That breaks
+when both panels are at their stored maxima: each panel clamps to
+`rowWidth * 0.5` independently → combined can consume all of
+`rowWidth`, leaving the center below its 360px floor.
+
+Joint computation is the only way to correctly protect the center
+when both panels are visible. The pure helper lives in
+`src/lib/panel-layout.ts` — contexts stay focused on storage.
+
+### Known gotchas
+
+```
+- Don't mutate stored values on window resize. The user's drag
+  intent is sticky; the clamp is purely a presentation layer.
+
+- ResizeObserver fires synchronously after layout; wrap the
+  setSignal in a microtask or use untrack-safe update to avoid
+  infinite loops if any child's size depends on rowWidth.
+
+- When both panels are open at their stored maxima on a narrow
+  window, SUM(stored) can exceed rowWidth - minCenter.
+  Independent per-panel clamping leaves the center squeezed.
+  Fix: each panel's maxEffective accounts for the OTHER panel's
+  minimum:
+      sidebarMaxEff = min(stored, 0.5*row, row - 360 - diffMin)
+      diffMaxEff    = min(stored, 0.5*row, row - 360 - sidebarMin)
+  At narrow widths both hit their own minimums and combined layout
+  still fits.
+
+- `SplitDivider`'s drag-time math already reads rowWidth from
+  `getParentRect()` on every pointermove. If we pass the SAME
+  `minOther` that includes the other panel's min, the drag is
+  consistent with the render.
+
+- The diff panel's current SplitDivider call site does NOT pass
+  `minOther` — it uses the default 360. That default needs to
+  grow to 360 + (sidebarOpen ? 200 : 0). Likewise sidebar's
+  call site.
+```
+
+---
+
+## Implementation Blueprint
+
+### Data flow
+
+```
+                    ┌────────────────────────────┐
+                    │ ResizeObserver(sidebarRow) │
+                    └─────────────┬──────────────┘
+                                  │
+                              setRowWidth
+                                  │
+              ┌───────────────────┴──────────────────┐
+              │                                      │
+       sidebar.effectiveWidth            diffPanel.effectiveWidth
+       (projectPath, rowWidth,             (projectPath, rowWidth,
+        otherPanelMinSpace)                 otherPanelMinSpace)
+              │                                      │
+          <aside>                              <div><DiffPanel/>
+          style={width}                        style={width}
+```
+
+### Types / constants
+
+```typescript
+// src/lib/panel-layout.ts — single source of truth for dimensions
+export const SIDEBAR_MIN = 200;
+export const SIDEBAR_MAX = 500;
+export const DIFF_MIN   = 300;
+export const DIFF_MAX   = 800;
+export const CENTER_MIN = 360;
+
+export type PanelLayoutInput = {
+  rowWidth: number;
+  sidebarVisible: boolean;
+  diffOpen: boolean;
+  sidebarStored: number;
+  diffStored: number;
+};
+export type PanelLayout = {
+  sidebarEff: number;
+  diffEff: number;
+  diffVisible: boolean; // auto-hide flag (see below)
+};
+
+export function computePanelLayout(input: PanelLayoutInput): PanelLayout
+```
+
+### Algorithm (inside `computePanelLayout`)
+
+```
+1. If rowWidth <= 0 (pre-measure tick): return stored widths as-is.
+
+2. diffFits = diffOpen && rowWidth >=
+     DIFF_MIN + CENTER_MIN + (sidebarVisible ? SIDEBAR_MIN : 0)
+   — This is the non-destructive auto-hide test.
+
+3. Only sidebar visible: clamp to [SIDEBAR_MIN, min(SIDEBAR_MAX,
+   rowWidth - CENTER_MIN)].
+
+4. Only diff visible: symmetric with DIFF_MIN / DIFF_MAX.
+
+5. Both visible:
+   sidebarPref = min(sidebarStored, SIDEBAR_MAX, rowWidth * 0.5)
+   diffPref    = min(diffStored,    DIFF_MAX,    rowWidth * 0.5)
+   available   = rowWidth - CENTER_MIN
+   if sidebarPref + diffPref <= available:
+     return preferred widths (clamped to own min)
+   else:
+     ratio = available / (sidebarPref + diffPref)
+     sidebarEff = max(SIDEBAR_MIN, sidebarPref * ratio)
+     diffEff    = max(DIFF_MIN,    diffPref    * ratio)
+```
+
+This guarantees: center ≥ CENTER_MIN whenever diff is visible
+(auto-hide fires before the algorithm would have to violate it).
+
+### Tasks (in order)
+
+```yaml
+Task 1: src/lib/panel-layout.ts — pure helper + constants
+  - EXPORT: SIDEBAR_MIN, SIDEBAR_MAX, DIFF_MIN, DIFF_MAX, CENTER_MIN
+  - EXPORT: computePanelLayout(input) per the algorithm above
+
+Task 2: sidebar-panel.tsx — accept width via prop
+  - ADD: `width: number` to Props
+  - REPLACE: `sidebar.widthFor(props.projectPath)` → `props.width`
+  - KEEP: collapse Show wrapper as-is
+
+Task 3: App.tsx — ResizeObserver + createMemo(panelLayout)
+  - SIGNAL: `[rowWidth, setRowWidth] = createSignal(0)`
+  - ON MOUNT: ResizeObserver(sidebarRowRef) → setRowWidth
+  - MEMO: `panelLayout = createMemo(() => computePanelLayout({...}))`
+    reads from sidebar, diffPanel, rowWidth signals
+
+Task 4: App.tsx — wire renders to panelLayout()
+  - <SidebarPanel width={panelLayout().sidebarEff} />
+  - Sidebar SplitDivider: width, minOther (CENTER_MIN + DIFF_MIN if
+    diff visible else CENTER_MIN), minSelf=SIDEBAR_MIN
+  - Diff <Show when={panelLayout().diffVisible}> so auto-hide works
+  - Diff SplitDivider + wrapper <div>: width = panelLayout().diffEff
+```
+
+### Pseudocode — App.tsx wiring
+
+```tsx
+const [rowWidth, setRowWidth] = createSignal(0);
+
+onMount(() => {
+  const ro = new ResizeObserver((entries) => {
+    const e = entries[0];
+    if (e) setRowWidth(e.contentRect.width);
+  });
+  ro.observe(sidebarRowRef);
+  onCleanup(() => ro.disconnect());
+});
+
+const sidebarVisible = () =>
+  !sidebar.collapsed() && activeProjectPath() !== null;
+const diffVisible = () => {
+  const p = activeProjectPath();
+  return p !== null && diffPanel.isOpen(p);
+};
+
+const sidebarEffective = (p: string) =>
+  sidebar.effectiveWidthFor(
+    p,
+    rowWidth(),
+    diffVisible() ? DIFF_MIN : 0,
+  );
+const diffEffective = (p: string) =>
+  diffPanel.effectiveWidthFor(
+    p,
+    rowWidth(),
+    sidebarVisible() ? SIDEBAR_MIN : 0,
+  );
+
+// Mount:
+<SidebarPanel projectPath={p()} width={sidebarEffective(p())} ... />
+<SplitDivider
+  edge="left"
+  width={sidebarEffective(p())}
+  minSelf={SIDEBAR_MIN}
+  minOther={CENTER_MIN + (diffVisible() ? DIFF_MIN : 0)}
+  maxFraction={0.5}
+  ...
+/>
+...
+<div style={{ width: `${diffEffective(p())}px` }}>
+  <DiffPanel projectPath={p()} />
+</div>
+<SplitDivider
+  width={diffEffective(p())}
+  minSelf={DIFF_MIN}
+  minOther={CENTER_MIN + (sidebarVisible() ? SIDEBAR_MIN : 0)}
+  ...
+/>
+```
+
+---
+
+## Validation Loop
+
+### Level 1: static checks
+
+```bash
+bun run typecheck
+cd src-tauri && cargo check           # no Rust touched
+cd src-tauri && cargo clippy -- -D warnings
+```
+
+### Level 2: manual integration
+
+```bash
+bun tauri dev
+```
+
+Steps:
+1. Open a project. Set sidebar to 360px, open diff panel at 640px.
+2. Shrink the window from, say, 1400 → 900 → 720 → 600.
+3. At each step: sidebar + center + diff visually stay
+   well-proportioned; center never drops below ~360px until both
+   panels hit their mins (200 / 300).
+4. Grow the window back to 1400. Sidebar and diff return to 360 /
+   640.
+5. Check `localStorage` in devtools:
+   `sidebarWidth:<path>` still 360; `diffPanelWidth:<path>` still
+   640. Never mutated by the resize cycle.
+6. In a narrow window, grab the sidebar's drag handle and try to
+   widen it. The drag clamp matches the render clamp — can't
+   drag into the diff panel's min zone.
+7. Close the diff panel; the sidebar can expand to 50% of the
+   (larger) available row.
+
+---
+
+## Final Checklist
+
+- [ ] Frontend typecheck + cargo check + clippy clean
+- [ ] Proportional behavior verified by eye across a 1400→600
+      resize sweep
+- [ ] Stored `localStorage` values unchanged by window resize
+- [ ] Drag-time clamp still consistent (no "drag shows one width,
+      release snaps to another")
+- [ ] Regression: opening/closing diff panel still works; Cmd+B
+      still works; per-project width from PRP 010 still persists
+
+---
+
+## Anti-Patterns to Avoid
+
+- ❌ Don't mutate stored width on window resize. Stored = user's
+  drag intent, effective = what we show.
+- ❌ Don't `setTimeout` / debounce the ResizeObserver. The user's
+  resize gesture is fluid; stutter here is obvious.
+- ❌ Don't hand-roll a `window.addEventListener("resize", ...)` —
+  ResizeObserver on the parent row is the right primitive.
+- ❌ Don't let sidebar-panel.tsx import diff-panel state. Width is
+  computed at the mount site (App.tsx), which is the only place
+  that knows about both panels.
+
+---
+
+## Notes
+
+- The `CENTER_MIN = 360` constant is also implied in the diff
+  panel's current SplitDivider default. Worth promoting to a
+  single shared constant later — but not in this PRP (YAGNI on
+  the refactor; value is identical in all call sites today).
+- Follow-up idea (not this PRP): also honor an absolute cap
+  (e.g. 600px hard max) so wide monitors don't get a 1200px
+  sidebar. Defer until someone asks.

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/cli": "^2",
+        "@types/bun": "^1.3.13",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.6.2",
         "vite": "^6.0.3",
@@ -271,11 +272,15 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -298,6 +303,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
 
@@ -466,6 +473,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "serve": "vite preview",
     "tauri": "tauri",
     "typecheck": "tsc --noEmit",
+    "test": "bun test",
     "release:mac": "tauri build --target universal-apple-darwin"
   },
   "license": "MIT",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/cli": "^2",
+    "@types/bun": "^1.3.13",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,12 @@ import { ShellPanelProvider, useShellPanel } from "@/context/shell-panel";
 import { installGlobalErrorForwarding } from "@/lib/debug-log";
 import { DiffPanel } from "@/components/diff-panel/diff-panel";
 import { SplitDivider } from "@/components/diff-panel/split-pane";
+import {
+  CENTER_MIN,
+  DIFF_MIN,
+  SIDEBAR_MIN,
+  computePanelLayout,
+} from "@/lib/panel-layout";
 import { ShellTerminalPanel } from "@/components/shell-terminal/shell-terminal-panel";
 import { displayLabel } from "@/lib/session-label";
 
@@ -90,6 +96,32 @@ function Shell() {
   const shellPanel = useShellPanel();
   let splitContainerRef!: HTMLDivElement;
   let sidebarRowRef!: HTMLDivElement;
+
+  // Live width of the outer flex row that hosts sidebar + center + diff
+  // panel. Drives the proportional shrink logic below. Updated by a
+  // ResizeObserver installed onMount; zero until first measurement so the
+  // contexts' effectiveWidthFor() fallback to stored width during the
+  // first render tick.
+  const [rowWidth, setRowWidth] = createSignal(0);
+
+  const sidebarVisible = () =>
+    !sidebar.collapsed() && activeProjectPath() !== null;
+
+  // Combined layout: we compute BOTH panels' effective widths together
+  // because the interaction between them matters. Each panel capped
+  // independently at row*0.5 lets them both reach 50%, leaving nothing
+  // for the center. `computePanelLayout` does the joint clamp and the
+  // auto-hide decision in one pure pass.
+  const panelLayout = createMemo(() => {
+    const p = activeProjectPath();
+    return computePanelLayout({
+      rowWidth: rowWidth(),
+      sidebarVisible: sidebarVisible(),
+      diffOpen: p !== null && diffPanel.isOpen(p),
+      sidebarStored: p !== null ? sidebar.widthFor(p) : 0,
+      diffStored: p !== null ? diffPanel.widthFor(p) : 0,
+    });
+  });
 
   // Remembered active tab per project. Set BEFORE changing activeProjectPath
   // (inside setActiveProjectPath) so it's never wrong when the switch effect
@@ -166,6 +198,19 @@ function Shell() {
       { defer: true },
     ),
   );
+
+  // Track the outer flex row's width so the sidebar and diff panel can
+  // clamp their rendered widths on window resize without mutating stored
+  // preferences. ResizeObserver's callback is already rAF-aligned by the
+  // browser — no debounce needed.
+  onMount(() => {
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0];
+      if (e) setRowWidth(e.contentRect.width);
+    });
+    ro.observe(sidebarRowRef);
+    onCleanup(() => ro.disconnect());
+  });
 
   // Seed recent projects with the project loaded from localStorage on boot.
   onMount(() => {
@@ -670,6 +715,7 @@ function Shell() {
             {(p) => (
               <SidebarPanel
                 projectPath={p()}
+                width={panelLayout().sidebarEff}
                 sessionsContent={
                   <SessionsList
                     projectPath={p()}
@@ -696,12 +742,14 @@ function Shell() {
             {(p) => (
               <SplitDivider
                 edge="left"
-                width={sidebar.widthFor(p())}
+                width={panelLayout().sidebarEff}
                 onResize={(w) => sidebar.setWidth(p(), w)}
                 onResizeEnd={(w) => sidebar.setWidth(p(), w)}
                 getParentRect={() => sidebarRowRef.getBoundingClientRect()}
-                minSelf={200}
-                minOther={360}
+                minSelf={SIDEBAR_MIN}
+                minOther={
+                  CENTER_MIN + (panelLayout().diffVisible ? DIFF_MIN : 0)
+                }
                 maxFraction={0.5}
               />
             )}
@@ -759,20 +807,29 @@ function Shell() {
                 </Show>
               </div>
             </section>
-            <Show when={activeProjectPath() && diffPanel.isOpen(activeProjectPath()!) ? activeProjectPath() : null}>
+            <Show
+              when={
+                panelLayout().diffVisible ? activeProjectPath() : null
+              }
+            >
               {(p) => (
                 <>
                   <SplitDivider
-                    width={diffPanel.widthFor(p())}
+                    width={panelLayout().diffEff}
                     onResize={(w) => diffPanel.setWidth(p(), w)}
                     onResizeEnd={(w) => diffPanel.setWidth(p(), w)}
                     getParentRect={() =>
                       splitContainerRef.getBoundingClientRect()
                     }
+                    minSelf={DIFF_MIN}
+                    minOther={
+                      CENTER_MIN + (sidebarVisible() ? SIDEBAR_MIN : 0)
+                    }
+                    maxFraction={0.5}
                   />
                   <div
                     class="shrink-0 min-h-0 flex flex-col overflow-hidden"
-                    style={{ width: `${diffPanel.widthFor(p())}px` }}
+                    style={{ width: `${panelLayout().diffEff}px` }}
                   >
                     <DiffPanel projectPath={p()} />
                   </div>

--- a/src/components/sidebar-panel.tsx
+++ b/src/components/sidebar-panel.tsx
@@ -5,6 +5,9 @@ import { SidebarTabs } from "./sidebar-tabs";
 
 type Props = {
   projectPath: string;
+  /** Effective (clamped-to-window) width in px. Computed by App.tsx so the
+   *  clamp stays consistent with the diff panel's side of the layout. */
+  width: number;
   sessionsContent: JSX.Element;
   filesContent: JSX.Element;
 };
@@ -20,7 +23,7 @@ export function SidebarPanel(props: Props) {
     <Show when={!sidebar.collapsed()}>
       <aside
         class="shrink-0 border-r border-neutral-800 flex flex-col min-h-0 overflow-hidden bg-neutral-950"
-        style={{ width: `${sidebar.widthFor(props.projectPath)}px` }}
+        style={{ width: `${props.width}px` }}
       >
         <div class="px-3 py-2 border-b border-neutral-800">
           <div class="text-[10px] uppercase tracking-wider text-neutral-500">

--- a/src/lib/panel-layout.test.ts
+++ b/src/lib/panel-layout.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CENTER_MIN,
+  DIFF_MAX,
+  DIFF_MIN,
+  SIDEBAR_MAX,
+  SIDEBAR_MIN,
+  computePanelLayout,
+} from "./panel-layout";
+
+describe("computePanelLayout", () => {
+  test("pre-measure tick returns stored widths without clamping", () => {
+    const r = computePanelLayout({
+      rowWidth: 0,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 280,
+      diffStored: 640,
+    });
+    expect(r.sidebarEff).toBe(280);
+    expect(r.diffEff).toBe(640);
+    expect(r.diffVisible).toBe(true);
+  });
+
+  test("only sidebar visible: clamps against rowWidth - CENTER_MIN", () => {
+    const r = computePanelLayout({
+      rowWidth: 900,
+      sidebarVisible: true,
+      diffOpen: false,
+      sidebarStored: 700,
+      diffStored: 640,
+    });
+    expect(r.sidebarEff).toBeLessThanOrEqual(SIDEBAR_MAX);
+    expect(r.diffEff).toBe(0);
+    expect(r.diffVisible).toBe(false);
+  });
+
+  test("only diff visible: clamps against rowWidth - CENTER_MIN", () => {
+    const r = computePanelLayout({
+      rowWidth: 900,
+      sidebarVisible: false,
+      diffOpen: true,
+      sidebarStored: 280,
+      diffStored: 900,
+    });
+    expect(r.sidebarEff).toBe(0);
+    expect(r.diffEff).toBeLessThanOrEqual(DIFF_MAX);
+    expect(r.diffEff).toBe(Math.min(DIFF_MAX, 900 - CENTER_MIN));
+    expect(r.diffVisible).toBe(true);
+  });
+
+  test("auto-hides diff when window narrower than sidebar + diff + center mins", () => {
+    const threshold = DIFF_MIN + CENTER_MIN + SIDEBAR_MIN; // 860
+    const r = computePanelLayout({
+      rowWidth: threshold - 1,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 280,
+      diffStored: 640,
+    });
+    expect(r.diffVisible).toBe(false);
+    expect(r.diffEff).toBe(0);
+    // sidebar takes what remains after CENTER_MIN
+    expect(r.sidebarEff + CENTER_MIN).toBeLessThanOrEqual(threshold - 1);
+  });
+
+  test("both visible with defaults on a medium window: center stays >= CENTER_MIN", () => {
+    const rowWidth = 1000;
+    const r = computePanelLayout({
+      rowWidth,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 280,
+      diffStored: 640,
+    });
+    expect(r.diffVisible).toBe(true);
+    const center = rowWidth - r.sidebarEff - r.diffEff;
+    expect(center).toBeGreaterThanOrEqual(CENTER_MIN);
+  });
+
+  // The blocker case the advisor caught: at the auto-hide threshold
+  // exactly, proportional scaling bumped one panel UP to its min and
+  // left the center at 357.2px. The second-pass overshoot correction
+  // must restore the 360px floor.
+  test("both visible at auto-hide threshold: second-pass keeps center at CENTER_MIN", () => {
+    const rowWidth = DIFF_MIN + CENTER_MIN + SIDEBAR_MIN; // 860
+    const r = computePanelLayout({
+      rowWidth,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 280,
+      diffStored: 640,
+    });
+    expect(r.diffVisible).toBe(true);
+    const center = rowWidth - r.sidebarEff - r.diffEff;
+    expect(center).toBeGreaterThanOrEqual(CENTER_MIN);
+  });
+
+  test("both visible: never below individual mins", () => {
+    const r = computePanelLayout({
+      rowWidth: 870,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 1000, // wants more than it'll get
+      diffStored: 1000,
+    });
+    expect(r.sidebarEff).toBeGreaterThanOrEqual(SIDEBAR_MIN);
+    expect(r.diffEff).toBeGreaterThanOrEqual(DIFF_MIN);
+  });
+
+  test("both visible on wide window: respects absolute maxes, center gets leftover", () => {
+    const rowWidth = 2400;
+    const r = computePanelLayout({
+      rowWidth,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: SIDEBAR_MAX + 200, // asks for more than cap
+      diffStored: DIFF_MAX + 200,
+    });
+    expect(r.sidebarEff).toBeLessThanOrEqual(SIDEBAR_MAX);
+    expect(r.diffEff).toBeLessThanOrEqual(DIFF_MAX);
+    const center = rowWidth - r.sidebarEff - r.diffEff;
+    expect(center).toBeGreaterThanOrEqual(CENTER_MIN);
+  });
+
+  test("both visible: sum never exceeds rowWidth - CENTER_MIN", () => {
+    // Stress across a sweep — this is the core invariant.
+    const stored = { sidebar: 400, diff: 700 };
+    for (let w = 860; w <= 2000; w += 37) {
+      const r = computePanelLayout({
+        rowWidth: w,
+        sidebarVisible: true,
+        diffOpen: true,
+        sidebarStored: stored.sidebar,
+        diffStored: stored.diff,
+      });
+      if (!r.diffVisible) continue;
+      const center = w - r.sidebarEff - r.diffEff;
+      expect(center).toBeGreaterThanOrEqual(CENTER_MIN);
+    }
+  });
+
+  test("stored widths are not echoed when they exceed the row budget", () => {
+    const r = computePanelLayout({
+      rowWidth: 1200,
+      sidebarVisible: true,
+      diffOpen: true,
+      sidebarStored: 1000,
+      diffStored: 1000,
+    });
+    expect(r.sidebarEff + r.diffEff).toBeLessThanOrEqual(1200 - CENTER_MIN);
+  });
+});

--- a/src/lib/panel-layout.ts
+++ b/src/lib/panel-layout.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure helpers that decide how the side-docked panels (Sessions/Files sidebar
+ * and right-hand diff panel) share the outer flex row on window resize. The
+ * core concern is that clamping each panel independently to
+ * `rowWidth - otherMin` leaves the center below its CENTER_MIN when BOTH
+ * panels are at their stored maxima. We compute both effective widths
+ * together so the center is always protected.
+ *
+ * Stored widths (in localStorage) are never mutated here — this is purely a
+ * presentation-time projection from stored to what the user sees on screen.
+ */
+
+export const SIDEBAR_MIN = 200;
+export const SIDEBAR_MAX = 500;
+export const DIFF_MIN = 300;
+export const DIFF_MAX = 800;
+export const CENTER_MIN = 360;
+
+export type PanelLayoutInput = {
+  rowWidth: number;
+  sidebarVisible: boolean;
+  diffOpen: boolean;
+  sidebarStored: number;
+  diffStored: number;
+};
+
+export type PanelLayout = {
+  sidebarEff: number;
+  diffEff: number;
+  /** Diff is auto-hidden when the window is too narrow to host sidebar (if
+   *  visible) + diff + a usable center. The user's `diffPanelOpen` flag in
+   *  localStorage is unaffected. */
+  diffVisible: boolean;
+};
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(v, hi));
+}
+
+export function computePanelLayout(input: PanelLayoutInput): PanelLayout {
+  const { rowWidth, sidebarVisible, diffOpen, sidebarStored, diffStored } =
+    input;
+
+  // Pre-measure tick: ResizeObserver hasn't fired yet. Fall back to stored
+  // widths so the first paint doesn't flicker at 0.
+  if (rowWidth <= 0) {
+    return {
+      sidebarEff: sidebarVisible ? sidebarStored : 0,
+      diffEff: diffOpen ? diffStored : 0,
+      diffVisible: diffOpen,
+    };
+  }
+
+  const diffFits =
+    diffOpen &&
+    rowWidth >= DIFF_MIN + CENTER_MIN + (sidebarVisible ? SIDEBAR_MIN : 0);
+
+  if (!sidebarVisible && !diffFits) {
+    return { sidebarEff: 0, diffEff: 0, diffVisible: false };
+  }
+
+  if (sidebarVisible && !diffFits) {
+    const maxSelf = Math.min(SIDEBAR_MAX, rowWidth - CENTER_MIN);
+    const sidebarEff = clamp(sidebarStored, SIDEBAR_MIN, maxSelf);
+    return { sidebarEff, diffEff: 0, diffVisible: false };
+  }
+
+  if (!sidebarVisible && diffFits) {
+    const maxSelf = Math.min(DIFF_MAX, rowWidth - CENTER_MIN);
+    const diffEff = clamp(diffStored, DIFF_MIN, maxSelf);
+    return { sidebarEff: 0, diffEff, diffVisible: true };
+  }
+
+  // Both visible. First compute each panel's "preferred" width respecting
+  // its own absolute max and the 50%-of-row cap. Then if the sum exceeds
+  // rowWidth - CENTER_MIN, scale both down proportionally but never below
+  // their individual mins.
+  const half = rowWidth * 0.5;
+  const sidebarPref = Math.min(sidebarStored, SIDEBAR_MAX, half);
+  const diffPref = Math.min(diffStored, DIFF_MAX, half);
+  const available = rowWidth - CENTER_MIN;
+
+  if (sidebarPref + diffPref <= available) {
+    return {
+      sidebarEff: Math.max(SIDEBAR_MIN, sidebarPref),
+      diffEff: Math.max(DIFF_MIN, diffPref),
+      diffVisible: true,
+    };
+  }
+
+  const ratio = available / (sidebarPref + diffPref);
+  const sidebarScaled = sidebarPref * ratio;
+  const diffScaled = diffPref * ratio;
+  let sidebarEff = Math.max(SIDEBAR_MIN, sidebarScaled);
+  let diffEff = Math.max(DIFF_MIN, diffScaled);
+
+  // When one panel's scaled-down width falls below its hard minimum it gets
+  // clamped up, which hands back extra pixels the other panel was counting
+  // on. Subtract that overshoot from the other side (respecting its own
+  // min) so the center keeps its CENTER_MIN floor.
+  const overshoot =
+    sidebarEff - sidebarScaled + (diffEff - diffScaled);
+  if (overshoot > 0) {
+    if (sidebarEff === SIDEBAR_MIN) {
+      diffEff = Math.max(DIFF_MIN, diffEff - overshoot);
+    } else {
+      sidebarEff = Math.max(SIDEBAR_MIN, sidebarEff - overshoot);
+    }
+  }
+  // Round DOWN to whole pixels — we render at pixel granularity anyway,
+  // and floor guarantees the CENTER_MIN invariant holds without relying on
+  // float precision (a 359.99999... center is indistinguishable from 360
+  // on screen but the invariant test cares).
+  return {
+    sidebarEff: Math.floor(sidebarEff),
+    diffEff: Math.floor(diffEff),
+    diffVisible: true,
+  };
+}


### PR DESCRIPTION
## Summary

- Side-docked panels (sidebar + diff panel) now give back space proportionally when the window shrinks, instead of holding their absolute stored widths and crushing the center terminal.
- Both panels are clamped **together** via a pure helper (`src/lib/panel-layout.ts` → `computePanelLayout`) so the center terminal is guaranteed a 360px floor whenever the diff panel is visible. Per-panel clamping on its own could let both hit 50% and leave 0% for the center — caught by the tests.
- Diff panel **auto-hides** non-destructively when the window can't host sidebar + diff + center at their minimums. `diffPanelOpen:<project>` in `localStorage` is untouched; widening the window brings it back.
- Panels never write to `localStorage` on window resize. Stored widths = user's drag intent; effective widths = what we render.
- Added absolute caps (`SIDEBAR_MAX=500`, `DIFF_MAX=800`) so ultrawide monitors give all the leftover space to the center — matches the "center is the priority" design.

Closes #4.

## What's new infra-wise

- `bun test` is wired as a script. First real tests in the repo: 10 cases for `computePanelLayout`, including the center-floor invariant across a rowWidth sweep. Added `@types/bun` as devDep.

## Known follow-up (not blocking)

During a drag, `SplitDivider` clamps using the other panel's **minimum** while the render memo clamps using its **preferred** width — so the cursor can lead the panel edge by a few pixels in edge cases. Not broken, just visually lagging. Fix would be to pass the memo's current effective widths into SplitDivider's `minOther`. Deferred.

## Test plan

Static: typecheck ✅ · `bun test` (10/10) ✅ · `cargo clippy -- -D warnings` ✅.

UI smoke test needed:

- [ ] With diff panel at its default (640) and sidebar at its default (280), shrink the window from ~1400 to ~900. Panels give back space proportionally; center stays ≥360px.
- [ ] Keep shrinking to ~800. Diff panel **disappears** (but `diffPanelOpen` in devtools localStorage is still `"1"`).
- [ ] Grow the window back to 1400. Diff panel reappears at 640.
- [ ] Across the full shrink/grow cycle, `sidebarWidth:<project>` and `diffPanelWidth:<project>` in localStorage do **not** change.
- [ ] On a wide window, drag sidebar as wide as you can → stops at 500 (SIDEBAR_MAX). Same for diff at 800.
- [ ] Per-project widths (from #3) still persist and restore correctly when switching projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)