### PR TITLE
fix(terminal): stagger fit on project/tab activation

### DIFF
--- a/src/components/terminal-view.tsx
+++ b/src/components/terminal-view.tsx
@@ -257,10 +257,18 @@ export function TerminalView(props: Props) {
   // When the tab becomes visible again, re-measure (size may have changed
   // while hidden), force a full redraw (xterm WebGL stops painting while the
   // canvas is `visibility: hidden` — without refresh the panel stays blank),
-  // and refocus so keyboard input lands in the active tab.
+  // and refocus so keyboard input lands in the active tab. Uses the same
+  // staggered-fit pattern as onMount because a single rAF caches a too-short
+  // height on project switch while the outer layout is still reflowing
+  // (per-project sidebar width from PR #5, panelLayout memo recompute from
+  // PR #6). Without the follow-ups, xterm ends up one row short and the
+  // shell prompt is clipped until the user's next keystroke triggers auto-
+  // scroll. Focus is claimed only on the first pass so later fits don't
+  // steal it back if the user already clicked elsewhere.
   createEffect(() => {
     if (!props.active) return;
-    requestAnimationFrame(() => {
+
+    const rafId = requestAnimationFrame(() => {
       safeFit();
       try {
         if (term) term.refresh(0, term.rows - 1);
@@ -268,6 +276,22 @@ export function TerminalView(props: Props) {
       } catch {
         // ignore
       }
+    });
+
+    const t180 = window.setTimeout(() => safeFit(), 180);
+    const t500 = window.setTimeout(() => {
+      safeFit();
+      try {
+        if (term) term.refresh(0, term.rows - 1);
+      } catch {
+        // ignore
+      }
+    }, 500);
+
+    onCleanup(() => {
+      cancelAnimationFrame(rafId);
+      window.clearTimeout(t180);
+      window.clearTimeout(t500);
     });
   });
 


### PR DESCRIPTION
## Summary

The activation path (`createEffect(() => props.active)` in `terminal-view.tsx`) did a **single rAF fit**, while `onMount` already had a staggered pattern at rAF + 180ms + 500ms with an explicit comment saying one-shot rAF is unreliable when the outer layout is still settling. PRs #5 and #6 amplified the outer reflow on project switch (per-project sidebar width, `panelLayout` memo recompute, diff panel auto-hide), so this race tipped over often enough to be visible: xterm measured one row short, the shell prompt sat clipped below the canvas, and only a keystroke (auto-scroll) brought it back.

Fix is 5 functional lines: mirror the onMount pattern inside the activation effect. Focus is claimed only on the first pass so the later fits don't steal focus if the user clicked elsewhere. Pending timers are cancelled via `onCleanup` when the effect re-runs, so rapid active-flips don't accumulate fits.

Closes #7.

## Test plan

Static: typecheck + `bun test` (10/10) + `cargo clippy -- -D warnings` ✅.

UI smoke test needed:

- [ ] Open two projects with noticeably different sidebar widths (e.g. 280 vs 400) and different diff panel states (one open, one closed).
- [ ] Bounce between them a few times. The terminal prompt should **always** be fully visible after the switch, no keystroke needed.
- [ ] Keep switching for ~30 seconds. No intermittent clipping.
- [ ] Click elsewhere (e.g. sidebar item) immediately after switching → focus should stay where you clicked, not snap back to the terminal 180ms or 500ms later.
- [ ] No regression on the first-mount case (open fresh project → prompt visible, focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)