### PR TITLE
feat(palette): Cmd+K command palette for sessions + files

### DIFF
--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -128,6 +128,74 @@ pub fn list_dir(path: String) -> Result<Vec<FsEntry>, String> {
     Ok(out)
 }
 
+#[derive(Serialize, Clone)]
+pub struct FileListResult {
+    pub files: Vec<String>,
+    pub truncated: bool,
+}
+
+/// Recursively list files under `project_path`, returning **relative** paths
+/// (forward-slash separated) sorted lexicographically. Honors gitignore and
+/// hides dotfiles + `.git/` — same filters as `list_dir`. Capped at 5000
+/// entries to keep both the IPC payload and the client-side filter bounded;
+/// caller gets `truncated: true` when the cap kicks in. Used by the Cmd+K
+/// command palette's Files source.
+#[tauri::command]
+pub fn list_files_recursive(project_path: String) -> Result<FileListResult, String> {
+    const CAP: usize = 5000;
+    let root = PathBuf::from(&project_path);
+    if !root.is_dir() {
+        return Err(format!("not a directory: {project_path}"));
+    }
+
+    let mut files = Vec::new();
+    let mut truncated = false;
+    // WalkBuilder defaults: hidden=true, git_ignore=true, parents=true. That
+    // gives us dotfile + gitignore filtering for free. We still hard-skip
+    // `.git/` via filter_entry because some repos don't have .gitignore
+    // entries for it.
+    let walker = WalkBuilder::new(&root)
+        .filter_entry(|entry| entry.file_name() != ".git")
+        .build();
+    for entry in walker.flatten() {
+        if files.len() >= CAP {
+            truncated = true;
+            break;
+        }
+        let path = entry.path();
+        if path == root {
+            continue;
+        }
+        let is_file = entry
+            .file_type()
+            .map(|t| t.is_file())
+            .unwrap_or(false);
+        if !is_file {
+            continue;
+        }
+        let rel = match path.strip_prefix(&root) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        // Forward-slash for consistent matching across platforms; the frontend
+        // displays them this way too.
+        let rel_str = rel
+            .components()
+            .filter_map(|c| match c {
+                std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/");
+        if rel_str.is_empty() {
+            continue;
+        }
+        files.push(rel_str);
+    }
+    files.sort();
+    Ok(FileListResult { files, truncated })
+}
+
 /// Walk upwards looking for a `.git` sibling — that's the project root.
 /// Falls back to the input if nothing is found (e.g. non-repo directories).
 fn find_project_root(start: &Path) -> PathBuf {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,7 @@ pub fn run() {
             debug_log::debug_log,
             debug_log::get_log_path,
             fs::list_dir,
+            fs::list_files_recursive,
             fs::watch_project,
             fs::unwatch_project,
             fs::fs_create_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,11 @@ import { OpenInProvider } from "@/context/open-in";
 import { EditorPtyProvider, useEditorPty } from "@/context/editor-pty";
 import { ShellPtyProvider, useShellPty } from "@/context/shell-pty";
 import { ShellPanelProvider, useShellPanel } from "@/context/shell-panel";
+import {
+  CommandPaletteProvider,
+  useCommandPalette,
+} from "@/context/command-palette";
+import { CommandPalette } from "@/components/command-palette";
 import { installGlobalErrorForwarding } from "@/lib/debug-log";
 import { DiffPanel } from "@/components/diff-panel/diff-panel";
 import { SplitDivider } from "@/components/diff-panel/split-pane";
@@ -94,6 +99,7 @@ function Shell() {
   const editorPty = useEditorPty();
   const shellPty = useShellPty();
   const shellPanel = useShellPanel();
+  const commandPalette = useCommandPalette();
   let splitContainerRef!: HTMLDivElement;
   let sidebarRowRef!: HTMLDivElement;
 
@@ -239,6 +245,14 @@ function Shell() {
       if (mod && !e.shiftKey && !e.altKey && e.key === "b") {
         e.preventDefault();
         sidebar.toggleCollapsed();
+        return;
+      }
+      // Cmd+K opens the command palette (Sessions + Files quick search).
+      // Toggle so a second press from inside the palette also closes it,
+      // mirroring how Cmd+B and Cmd+J behave.
+      if (mod && !e.shiftKey && !e.altKey && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        commandPalette.toggle();
         return;
       }
       if (mod && e.shiftKey && !e.altKey && (e.key === "d" || e.key === "D")) {
@@ -680,6 +694,10 @@ function Shell() {
 
   return (
     <div class="h-screen w-screen flex flex-col bg-neutral-950 text-neutral-200 overflow-hidden">
+      <CommandPalette
+        projectPath={activeProjectPath()}
+        onSelectSession={handleSelectSession}
+      />
       <Titlebar
         hasActiveProject={activeProjectPath() !== null}
         activeProjectPath={activeProjectPath()}
@@ -924,7 +942,9 @@ export default function App() {
                   <ShellPtyProvider>
                     <TerminalProvider>
                       <SessionWatcherProvider>
-                        <Shell />
+                        <CommandPaletteProvider>
+                          <Shell />
+                        </CommandPaletteProvider>
                       </SessionWatcherProvider>
                     </TerminalProvider>
                   </ShellPtyProvider>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,397 @@
+import {
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  For,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+import { invoke } from "@tauri-apps/api/core";
+import { MessageSquare, Search } from "lucide-solid";
+import { useCommandPalette } from "@/context/command-palette";
+import { useDiffPanel } from "@/context/diff-panel";
+import { displayLabel } from "@/lib/session-label";
+import { iconForFile } from "@/lib/file-icon";
+import type { SessionMeta } from "@/components/sessions-list";
+
+const MAX_SESSIONS = 50;
+const MAX_FILES = 100;
+
+/** Glob → case-insensitive regex. `*` → `.*`, `?` → `.`, every other regex
+ *  meta-char is escaped. Plain text falls through and behaves like a substring
+ *  search (regex without anchors). */
+function buildMatcher(query: string): RegExp | null {
+  const q = query.trim();
+  if (!q) return null;
+  const escaped = q.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const pattern = escaped.replace(/\*/g, ".*").replace(/\?/g, ".");
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return null;
+  }
+}
+
+type FileListResult = { files: string[]; truncated: boolean };
+
+export function CommandPalette(props: {
+  projectPath: string | null;
+  onSelectSession: (meta: SessionMeta) => void;
+}) {
+  const palette = useCommandPalette();
+  const diffPanel = useDiffPanel();
+
+  const [query, setQuery] = createSignal("");
+  const [activeIdx, setActiveIdx] = createSignal(0);
+
+  // Reset state on each open so the palette never inherits a stale query.
+  createEffect(
+    on(palette.isOpen, (open) => {
+      if (open) {
+        setQuery("");
+        setActiveIdx(0);
+      }
+    }),
+  );
+
+  const [sessions] = createResource(
+    () =>
+      palette.isOpen() && props.projectPath
+        ? { path: props.projectPath, _open: palette.isOpen() }
+        : null,
+    async ({ path }) => {
+      return (await invoke("list_sessions_for_project", {
+        projectPath: path,
+      })) as SessionMeta[];
+    },
+  );
+
+  const [files] = createResource(
+    () =>
+      palette.isOpen() && props.projectPath
+        ? { path: props.projectPath, _open: palette.isOpen() }
+        : null,
+    async ({ path }) => {
+      return (await invoke("list_files_recursive", {
+        projectPath: path,
+      })) as FileListResult;
+    },
+  );
+
+  const sessionsList = createMemo(() => {
+    const list = sessions() ?? [];
+    const m = buildMatcher(query());
+    if (!m) return list.slice(0, MAX_SESSIONS);
+    return list
+      .filter((s) => m.test(displayLabel(s)))
+      .slice(0, MAX_SESSIONS);
+  });
+
+  const filesList = createMemo(() => {
+    const list = files()?.files ?? [];
+    const m = buildMatcher(query());
+    if (!m) return list.slice(0, MAX_FILES);
+    return list.filter((p) => m.test(p)).slice(0, MAX_FILES);
+  });
+
+  const totalCount = createMemo(
+    () => sessionsList().length + filesList().length,
+  );
+
+  // Reset highlight whenever the visible result set changes.
+  createEffect(
+    on(query, () => {
+      setActiveIdx(0);
+    }),
+  );
+
+  function selectAt(idx: number) {
+    const ss = sessionsList();
+    if (idx < ss.length) {
+      const meta = ss[idx];
+      if (!meta) return;
+      props.onSelectSession(meta);
+      palette.close();
+      return;
+    }
+    const fs = filesList();
+    const fileIdx = idx - ss.length;
+    const rel = fs[fileIdx];
+    if (!rel || !props.projectPath) return;
+    diffPanel.openFile(props.projectPath, rel);
+    palette.close();
+  }
+
+  function moveBy(delta: number) {
+    const n = totalCount();
+    if (n === 0) return;
+    setActiveIdx((i) => (i + delta + n) % n);
+  }
+
+  // Window-level keydown while the palette is open. Bound here (instead of on
+  // the modal panel via onKeyDown) so that nav still works after focus has
+  // been pulled out of the input — e.g. by diff-panel/editor focusing itself
+  // when a previous selection opened a file. Capture phase so we pre-empt
+  // anything xterm.js would try to swallow.
+  createEffect(() => {
+    if (!palette.isOpen()) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        palette.close();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        e.stopPropagation();
+        moveBy(1);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        e.stopPropagation();
+        moveBy(-1);
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        selectAt(activeIdx());
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    onCleanup(() => window.removeEventListener("keydown", handler, true));
+  });
+
+  return (
+    <Show when={palette.isOpen()}>
+      <Portal>
+        <div
+          class="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] bg-black/50"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) palette.close();
+          }}
+        >
+          <div class="w-[640px] max-w-[90vw] max-h-[70vh] flex flex-col rounded-lg border border-neutral-700 bg-neutral-900 shadow-2xl overflow-hidden">
+            <SearchInput
+              query={query()}
+              onQueryChange={setQuery}
+              hasProject={!!props.projectPath}
+            />
+            <div class="flex-1 min-h-0 overflow-y-auto">
+              <Show when={!props.projectPath}>
+                <Empty message="Open a project first." />
+              </Show>
+              <Show
+                when={
+                  props.projectPath &&
+                  (sessions.loading || files.loading) &&
+                  totalCount() === 0
+                }
+              >
+                <Loading />
+              </Show>
+              <Show
+                when={
+                  props.projectPath &&
+                  !sessions.loading &&
+                  !files.loading &&
+                  totalCount() === 0
+                }
+              >
+                <Empty message="No matches." />
+              </Show>
+
+              <Show when={sessionsList().length > 0}>
+                <SectionHeader label="Sessions" />
+                <ul class="pb-1">
+                  <For each={sessionsList()}>
+                    {(s, i) => (
+                      <ResultRow
+                        active={i() === activeIdx()}
+                        onMouseEnter={() => setActiveIdx(i())}
+                        onClick={() => selectAt(i())}
+                        icon={
+                          <MessageSquare
+                            size={14}
+                            strokeWidth={2}
+                            class="text-neutral-500 shrink-0"
+                          />
+                        }
+                        primary={displayLabel(s)}
+                        secondary={null}
+                      />
+                    )}
+                  </For>
+                </ul>
+              </Show>
+
+              <Show when={filesList().length > 0}>
+                <SectionHeader label="Files" />
+                <ul class="pb-1">
+                  <For each={filesList()}>
+                    {(rel, i) => {
+                      const lastSlash = rel.lastIndexOf("/");
+                      const dir =
+                        lastSlash >= 0 ? rel.slice(0, lastSlash + 1) : "";
+                      const base =
+                        lastSlash >= 0 ? rel.slice(lastSlash + 1) : rel;
+                      const icon = iconForFile(base);
+                      // Lazy accessor — sessionsList().length and i() can both
+                      // change after the row is created (different query, For
+                      // reordering), so capturing into a const would freeze a
+                      // stale index and break click/select.
+                      const globalIdx = () => sessionsList().length + i();
+                      return (
+                        <ResultRow
+                          active={globalIdx() === activeIdx()}
+                          onMouseEnter={() => setActiveIdx(globalIdx())}
+                          onClick={() => selectAt(globalIdx())}
+                          icon={
+                            <icon.Icon
+                              size={14}
+                              strokeWidth={2}
+                              class={`${icon.color} shrink-0`}
+                            />
+                          }
+                          primary={base}
+                          secondary={dir || null}
+                        />
+                      );
+                    }}
+                  </For>
+                </ul>
+                <Show when={files()?.truncated}>
+                  <div class="px-3 py-1.5 text-[10px] text-neutral-600 italic">
+                    File list capped at 5000. Refine your query for more.
+                  </div>
+                </Show>
+              </Show>
+            </div>
+            <Footer />
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+}
+
+function SearchInput(props: {
+  query: string;
+  onQueryChange: (s: string) => void;
+  hasProject: boolean;
+}) {
+  let inputRef!: HTMLInputElement;
+  const palette = useCommandPalette();
+
+  onMount(() => {
+    queueMicrotask(() => inputRef?.focus());
+  });
+
+  // Re-grab focus on every open. The mount-time autofocus is not enough: when
+  // the previous selection was a file, diffPanel.openFile pulls focus into
+  // the editor / preview tab, and on reopen we need to take it back so
+  // typing lands in the input (and so window-level keydown can use the input
+  // as the active element for things like text input).
+  createEffect(
+    on(palette.isOpen, (open) => {
+      if (open) queueMicrotask(() => inputRef?.focus());
+    }),
+  );
+
+  return (
+    <div class="flex items-center gap-2 px-3 border-b border-neutral-800">
+      <Search size={14} strokeWidth={2} class="text-neutral-500 shrink-0" />
+      <input
+        ref={inputRef}
+        type="text"
+        class="flex-1 bg-transparent py-3 text-sm text-neutral-100 placeholder:text-neutral-500 outline-none"
+        placeholder={
+          props.hasProject
+            ? "Search sessions and files (glob: * ?)…"
+            : "No active project"
+        }
+        value={props.query}
+        onInput={(e) => props.onQueryChange(e.currentTarget.value)}
+        disabled={!props.hasProject}
+        autocomplete="off"
+        spellcheck={false}
+      />
+    </div>
+  );
+}
+
+function SectionHeader(props: { label: string }) {
+  return (
+    <div class="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-neutral-500">
+      {props.label}
+    </div>
+  );
+}
+
+function ResultRow(props: {
+  active: boolean;
+  onMouseEnter: () => void;
+  onClick: () => void;
+  icon: any;
+  primary: string;
+  secondary: string | null;
+}) {
+  let ref!: HTMLLIElement;
+
+  createEffect(() => {
+    if (props.active) {
+      ref?.scrollIntoView({ block: "nearest" });
+    }
+  });
+
+  return (
+    <li
+      ref={ref}
+      class="px-3 py-1.5 flex items-center gap-2 cursor-pointer text-[13px]"
+      classList={{
+        "bg-neutral-800": props.active,
+      }}
+      onMouseEnter={props.onMouseEnter}
+      onClick={props.onClick}
+    >
+      {props.icon}
+      <Show when={props.secondary}>
+        <span class="text-neutral-500 truncate">{props.secondary}</span>
+      </Show>
+      <span
+        class="truncate"
+        classList={{
+          "text-neutral-100": props.active,
+          "text-neutral-300": !props.active,
+        }}
+      >
+        {props.primary}
+      </span>
+    </li>
+  );
+}
+
+function Loading() {
+  return <div class="px-3 py-4 text-xs text-neutral-500">Loading…</div>;
+}
+
+function Empty(props: { message: string }) {
+  return <div class="px-3 py-4 text-xs text-neutral-500">{props.message}</div>;
+}
+
+function Footer() {
+  return (
+    <div class="border-t border-neutral-800 px-3 py-1.5 text-[10px] text-neutral-500 flex items-center gap-3">
+      <span>↑↓ navigate</span>
+      <span>↵ open</span>
+      <span>esc close</span>
+      <span class="ml-auto">glob: * ?</span>
+    </div>
+  );
+}

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -2,12 +2,20 @@ import { Show } from "solid-js";
 import {
   PanelLeftClose,
   PanelLeftOpen,
+  Search,
   SquareTerminal,
 } from "lucide-solid";
 import { useSidebar } from "@/context/sidebar";
 import { useShellPanel } from "@/context/shell-panel";
+import { useCommandPalette } from "@/context/command-palette";
 import { GitSummaryPill } from "@/components/git-summary-pill";
 import { OpenInDropdown } from "@/components/open-in-dropdown";
+
+function basename(path: string): string {
+  const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+  const i = trimmed.lastIndexOf("/");
+  return i >= 0 ? trimmed.slice(i + 1) : trimmed;
+}
 
 type Props = {
   hasActiveProject: boolean;
@@ -21,6 +29,7 @@ type Props = {
 export function Titlebar(props: Props) {
   const sidebar = useSidebar();
   const shellPanel = useShellPanel();
+  const palette = useCommandPalette();
 
   return (
     <header
@@ -48,8 +57,28 @@ export function Titlebar(props: Props) {
         </button>
       </Show>
 
-      {/* Remaining space stays draggable. */}
-      <div class="flex-1 h-full" data-tauri-drag-region />
+      {/* Remaining space stays draggable; the search pill in the middle
+          breaks drag at the button itself. */}
+      <div
+        class="flex-1 h-full flex items-center justify-center"
+        data-tauri-drag-region
+      >
+        <Show when={props.activeProjectPath}>
+          {(p) => (
+            <button
+              class="h-7 w-[280px] max-w-[40vw] px-2.5 rounded-md bg-neutral-900 hover:bg-neutral-800 border border-neutral-800 hover:border-neutral-700 transition flex items-center gap-2 text-[12px] text-neutral-500 hover:text-neutral-300"
+              onClick={() => palette.open()}
+              title="Search sessions and files (⌘K)"
+            >
+              <Search size={12} strokeWidth={2} class="shrink-0" />
+              <span class="truncate flex-1 text-left">
+                Search {basename(p())}
+              </span>
+              <span class="shrink-0 text-neutral-600 text-[11px]">⌘K</span>
+            </button>
+          )}
+        </Show>
+      </div>
 
       <Show when={props.activeProjectPath}>
         {(p) => (

--- a/src/context/command-palette.tsx
+++ b/src/context/command-palette.tsx
@@ -1,0 +1,35 @@
+import {
+  createContext,
+  createSignal,
+  useContext,
+  type ParentProps,
+} from "solid-js";
+
+function makeCommandPaletteContext() {
+  const [isOpen, setOpen] = createSignal(false);
+
+  function open() {
+    setOpen(true);
+  }
+  function close() {
+    setOpen(false);
+  }
+  function toggle() {
+    setOpen((v) => !v);
+  }
+
+  return { isOpen, open, close, toggle };
+}
+
+const Ctx = createContext<ReturnType<typeof makeCommandPaletteContext>>();
+
+export function CommandPaletteProvider(props: ParentProps) {
+  const ctx = makeCommandPaletteContext();
+  return <Ctx.Provider value={ctx}>{props.children}</Ctx.Provider>;
+}
+
+export function useCommandPalette() {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useCommandPalette outside CommandPaletteProvider");
+  return v;
+}


### PR DESCRIPTION
Closes #9.

## Summary

- Centered Cmd+K modal that fuzzy-searches the active project's sessions and files in one sectioned list (Sessions on top, Files below). Selecting a session activates an existing tab or spawns `claude --resume <id>`; selecting a file opens it in the diff-panel preview via the existing `diffPanel.openFile` API.
- Search pill in the titlebar center ("Search <project> ⌘K") opens the same palette by mouse.
- New Rust command `list_files_recursive` walks the project gitignore-aware (mirroring `list_dir`'s filters, hard-skips `.git/`), capped at 5000 entries with a `truncated` flag. Glob (`*`, `?`) and substring queries resolved client-side as a single regex.

## Notable design choices

- **Unified list, not tabs.** Earlier draft had a Sessions/Files toggle; matched OpenCode's UX better with both sources visible at once under section headings, filtered by the same query.
- **Window-level keydown while open.** First test surfaced that arrows/Enter died after the first file pick, because `diffPanel.openFile` pulls focus into the editor — by the time the user reopened the palette, focus wasn't inside the modal anymore. Window-level capture-phase listener fixes that without fighting xterm.js for the keystrokes.
- **Lazy `globalIdx` accessor on file rows.** `sessionsList().length + i()` is read inside the click/hover handlers, not captured at row creation, so a different result mix on a second search doesn't fossilize stale indices.
- **No new deps.** Glob → regex is ~2 lines; recursive walker reuses `ignore::WalkBuilder` already in the crate.

## Test plan

- [x] ⌘K opens / closes (toggle); Esc + click-outside close
- [x] Titlebar pill click opens the same modal
- [x] Sessions section: substring filter; click already-open session activates its tab; click new session spawns \`claude --resume <id>\`
- [x] Files section: substring + \`*.tsx\`-style glob; click opens file in diff-panel preview
- [x] ↑↓ navigate across the Sessions↔Files section boundary; Enter opens
- [x] Re-open after picking a file: input refocused, click + arrows still work
- [x] \`bun run typecheck\` clean
- [x] \`cargo check\` + \`cargo clippy -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)