### PR TITLE
feat(file-tree): reveal in tree on diffPanel.openFile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
   useCommandPalette,
 } from "@/context/command-palette";
 import { CommandPalette } from "@/components/command-palette";
+import { RevealProvider, useReveal } from "@/context/reveal";
 import { installGlobalErrorForwarding } from "@/lib/debug-log";
 import { DiffPanel } from "@/components/diff-panel/diff-panel";
 import { SplitDivider } from "@/components/diff-panel/split-pane";
@@ -100,6 +101,7 @@ function Shell() {
   const shellPty = useShellPty();
   const shellPanel = useShellPanel();
   const commandPalette = useCommandPalette();
+  const reveal = useReveal();
   let splitContainerRef!: HTMLDivElement;
   let sidebarRowRef!: HTMLDivElement;
 
@@ -234,6 +236,23 @@ function Shell() {
       }
     });
     onCleanup(dispose);
+  });
+
+  // Reveal-in-tree: when diffPanel.openFile fires (Cmd+K palette, etc.), the
+  // <FileTree> may not be mounted yet because the sidebar is on Sessions.
+  // Switch the sidebar to Files first — that mounts <FileTree>, which then
+  // picks up the same pending reveal via its own effect and runs the walk +
+  // scroll + highlight. This effect lives in Shell (always mounted) so the
+  // tab-switch happens regardless of the current sidebar state.
+  let lastHandledTabSwitchId = 0;
+  createEffect(() => {
+    const r = reveal.pending();
+    if (!r) return;
+    if (r.id <= lastHandledTabSwitchId) return;
+    lastHandledTabSwitchId = r.id;
+    if (sidebar.activeTab(r.projectPath) !== "files") {
+      sidebar.setTab(r.projectPath, "files");
+    }
   });
 
   // Cmd+B toggles the sidebar, Cmd+Shift+D toggles the diff panel. Listening
@@ -935,23 +954,25 @@ export default function App() {
     <ProjectsProvider>
       <SidebarProvider>
         <GitProvider>
-          <DiffPanelProvider>
-            <OpenInProvider>
-              <EditorPtyProvider>
-                <ShellPanelProvider>
-                  <ShellPtyProvider>
-                    <TerminalProvider>
-                      <SessionWatcherProvider>
-                        <CommandPaletteProvider>
-                          <Shell />
-                        </CommandPaletteProvider>
-                      </SessionWatcherProvider>
-                    </TerminalProvider>
-                  </ShellPtyProvider>
-                </ShellPanelProvider>
-              </EditorPtyProvider>
-            </OpenInProvider>
-          </DiffPanelProvider>
+          <RevealProvider>
+            <DiffPanelProvider>
+              <OpenInProvider>
+                <EditorPtyProvider>
+                  <ShellPanelProvider>
+                    <ShellPtyProvider>
+                      <TerminalProvider>
+                        <SessionWatcherProvider>
+                          <CommandPaletteProvider>
+                            <Shell />
+                          </CommandPaletteProvider>
+                        </SessionWatcherProvider>
+                      </TerminalProvider>
+                    </ShellPtyProvider>
+                  </ShellPanelProvider>
+                </EditorPtyProvider>
+              </OpenInProvider>
+            </DiffPanelProvider>
+          </RevealProvider>
         </GitProvider>
       </SidebarProvider>
     </ProjectsProvider>

--- a/src/components/file-tree/file-tree.tsx
+++ b/src/components/file-tree/file-tree.tsx
@@ -28,6 +28,7 @@ import { useGit } from "@/context/git";
 import { useDiffPanel } from "@/context/diff-panel";
 import { useOpenIn } from "@/context/open-in";
 import { useEditorPty } from "@/context/editor-pty";
+import { useReveal } from "@/context/reveal";
 import { TreeNode } from "./tree-node";
 import {
   makeFileTreeStore,
@@ -117,6 +118,39 @@ export function FileTree(props: Props) {
   const diffPanel = useDiffPanel();
   const openIn = useOpenIn();
   const editorPty = useEditorPty();
+  const revealCtx = useReveal();
+
+  // Per-row DOM refs, keyed by absolute path. Populated by TreeNode via the
+  // `registerRef` prop (mount → set, cleanup → null). Used by reveal-in-tree
+  // to scroll a specific row into view without querying the DOM.
+  const nodeRefs = new Map<string, HTMLElement>();
+  function registerNodeRef(path: string, el: HTMLElement | null) {
+    if (el) nodeRefs.set(path, el);
+    else nodeRefs.delete(path);
+  }
+
+  // Transient highlight: set when a reveal lands, cleared after 1.2s. Tracked
+  // by absolute path. The setTimeout handle is held so a *new* reveal can
+  // cancel the prior timer — without that, the first reveal's clear would
+  // wipe the second reveal's highlight as soon as it fires.
+  const [highlightedPath, setHighlightedPath] = createSignal<string | null>(
+    null,
+  );
+  let highlightTimer: number | null = null;
+  function flashHighlight(absPath: string) {
+    if (highlightTimer !== null) {
+      clearTimeout(highlightTimer);
+      highlightTimer = null;
+    }
+    setHighlightedPath(absPath);
+    highlightTimer = window.setTimeout(() => {
+      setHighlightedPath((cur) => (cur === absPath ? null : cur));
+      highlightTimer = null;
+    }, 1200);
+  }
+  onCleanup(() => {
+    if (highlightTimer !== null) clearTimeout(highlightTimer);
+  });
 
   // Memoized store follows the prop — switching projects swaps the store.
   const store = createMemo(() => getStore(props.projectPath));
@@ -227,6 +261,60 @@ export function FileTree(props: Props) {
 
   onCleanup(() => {
     if (unlisten) unlisten();
+  });
+
+  /** Walk the project root → leaf chain expanding each ancestor in turn,
+   *  then wait one frame for the For to re-flatten and render the new rows
+   *  before scrolling the leaf into view + flashing a brief highlight.
+   *
+   *  Bails on the first failed `expandTo` (deleted dir, permission, …) —
+   *  no scroll, no highlight, just a console warn so we don't tear the
+   *  whole tree on transient races.
+   */
+  async function runReveal(rel: string) {
+    const segments = rel.split("/").filter(Boolean);
+    if (segments.length === 0) return;
+    const base = stripTrailingSlash(props.projectPath);
+    let walkPath = base;
+    const s = store();
+    // Expand every ancestor (everything up to the leaf — the leaf itself
+    // is a file, can't be expanded).
+    for (let i = 0; i < segments.length - 1; i++) {
+      walkPath = `${walkPath}/${segments[i]}`;
+      try {
+        await s.expandTo(walkPath);
+      } catch (err) {
+        console.warn("reveal: expandTo failed at", walkPath, err);
+        return;
+      }
+    }
+    const leafAbs = `${base}/${segments.join("/")}`;
+    // Two rAFs: first one settles the store mutation, second one waits for
+    // <For> to materialize the new rows so nodeRefs has the leaf entry.
+    await new Promise<void>((r) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => r())),
+    );
+    const el = nodeRefs.get(leafAbs);
+    if (el) el.scrollIntoView({ block: "nearest" });
+    setSelected(leafAbs);
+    flashHighlight(leafAbs);
+  }
+
+  // React to reveal requests originating in diffPanel.openFile (Cmd+K palette
+  // today; future: file-tree right-click "Reveal", etc.). Track lastHandledId
+  // so handler-driven mutations (sidebar.setTab, setSelected) don't re-fire
+  // the effect on the same payload.
+  let lastHandledRevealId = 0;
+  createEffect(() => {
+    const r = revealCtx.pending();
+    if (!r) return;
+    if (r.projectPath !== props.projectPath) return;
+    if (r.id <= lastHandledRevealId) return;
+    lastHandledRevealId = r.id;
+    // Sidebar tab-switch is handled in App.tsx so it can fire even when this
+    // component isn't mounted (sidebar on Sessions). Once the tab flips to
+    // Files, this component mounts and picks up the same pending reveal.
+    void runReveal(r.rel);
   });
 
   function openContextMenu(e: MouseEvent, path: string, isDir: boolean) {
@@ -552,6 +640,7 @@ export function FileTree(props: Props) {
                 node={r.node}
                 depth={r.depth}
                 selected={selected() === r.node.path}
+                highlighted={highlightedPath() === r.node.path}
                 status={statusMap().get(r.node.path)}
                 onToggle={(path) => void store().toggleDir(path)}
                 onSelect={(path) => setSelected(path)}
@@ -559,6 +648,7 @@ export function FileTree(props: Props) {
                 onContextMenu={openContextMenu}
                 onModClick={handleClickWithMods}
                 onDelete={(path, isDir) => void deleteEntry(path, isDir)}
+                registerRef={registerNodeRef}
               />
             );
           }}

--- a/src/components/file-tree/tree-node.tsx
+++ b/src/components/file-tree/tree-node.tsx
@@ -1,4 +1,4 @@
-import { Show } from "solid-js";
+import { onCleanup, onMount, Show } from "solid-js";
 import { ChevronRight, Folder, FolderOpen } from "lucide-solid";
 import { iconForFile } from "@/lib/file-icon";
 import { BADGE_COLOR, BADGE_LETTER, type FileStatus } from "@/lib/git-status";
@@ -17,6 +17,10 @@ type Props = {
   depth: number;
   selected: boolean;
   status?: FileStatus;
+  /** True while a reveal-in-tree request is highlighting this row. Painted
+   *  as a soft indigo wash that fades out via the existing `transition`
+   *  class; FileTree clears it after ~1.2s. */
+  highlighted?: boolean;
   onToggle: (path: string) => void;
   onSelect: (path: string) => void;
   onOpen: (path: string) => void;
@@ -27,15 +31,27 @@ type Props = {
   /** Delete / Backspace with the row focused triggers deletion (with
    *  confirm dialog on the parent's side). */
   onDelete: (path: string, isDir: boolean) => void;
+  /** FileTree passes a register/unregister pair so it can scroll a
+   *  specific row into view by absolute path (used by reveal-in-tree).
+   *  Optional — drag-only callers don't need it. */
+  registerRef?: (path: string, el: HTMLElement | null) => void;
 };
 
 export function TreeNode(props: Props) {
   const fileIcon = () => iconForFile(props.node.name);
 
+  let buttonRef: HTMLButtonElement | undefined;
   let pressStart: { x: number; y: number } | null = null;
   let dragging = false;
   let didDrag = false;
   let ghost: HTMLDivElement | null = null;
+
+  onMount(() => {
+    if (buttonRef) props.registerRef?.(props.node.path, buttonRef);
+  });
+  onCleanup(() => {
+    props.registerRef?.(props.node.path, null);
+  });
 
   function buildGhost(label: string): HTMLDivElement {
     const el = document.createElement("div");
@@ -167,6 +183,7 @@ export function TreeNode(props: Props) {
 
   return (
     <button
+      ref={buttonRef}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
@@ -179,10 +196,12 @@ export function TreeNode(props: Props) {
         props.onContextMenu(e, props.node.path, props.node.isDir);
       }}
       class={
-        "w-full flex items-center gap-1 px-2 py-0.5 text-[12px] text-left transition border-l-2 " +
-        (props.selected
-          ? "bg-neutral-800/60 border-indigo-500 text-neutral-100"
-          : "border-transparent text-neutral-300 hover:bg-neutral-900/60") +
+        "w-full flex items-center gap-1 px-2 py-0.5 text-[12px] text-left transition-colors duration-700 border-l-2 " +
+        (props.highlighted
+          ? "bg-indigo-500/20 border-indigo-400 text-neutral-100"
+          : props.selected
+            ? "bg-neutral-800/60 border-indigo-500 text-neutral-100"
+            : "border-transparent text-neutral-300 hover:bg-neutral-900/60") +
         (props.node.ignored ? " italic opacity-55" : "")
       }
       style={{ "padding-left": `${8 + props.depth * 12}px` }}

--- a/src/components/file-tree/use-file-tree.ts
+++ b/src/components/file-tree/use-file-tree.ts
@@ -127,6 +127,23 @@ export function makeFileTreeStore(projectPath: string) {
     });
   }
 
+  /** Force a directory expanded (idempotent), loading its children if not
+   *  already loaded. Unlike `toggleDir`, never collapses an already-expanded
+   *  directory — needed by reveal-in-tree to expand a chain of ancestors
+   *  without flipping any that the user had open. Throws if the load fails
+   *  so the caller can stop the walk.
+   */
+  async function expandTo(path: string) {
+    const node = findNodeMut(root, path);
+    if (!node || !node.isDir) return;
+    if (!node.loaded) {
+      await loadChildren(path);
+    }
+    updateNode(path, (n) => {
+      n.expanded = true;
+    });
+  }
+
   /** Re-list every currently-loaded directory, preserving expanded state
    *  for paths that still exist. Used by the header "refresh" button. */
   async function refresh() {
@@ -279,6 +296,7 @@ export function makeFileTreeStore(projectPath: string) {
     root,
     ensureLoaded,
     toggleDir,
+    expandTo,
     applyFsEvent,
     flatten,
     refresh,

--- a/src/context/diff-panel.tsx
+++ b/src/context/diff-panel.tsx
@@ -11,6 +11,7 @@ import {
   setDiffPanelOpen,
   setDiffPanelWidth,
 } from "@/lib/diff-panel-prefs";
+import { useReveal } from "@/context/reveal";
 
 const DEFAULT_WIDTH = 640;
 
@@ -43,6 +44,8 @@ function freshState(): ProjectPanelState {
 }
 
 function makeDiffPanelContext() {
+  const reveal = useReveal();
+
   // Open/closed state is per-project. Stored as a reactive Record so any read
   // of `isOpen(path)` subscribes to changes for that path, and persisted
   // under `diffPanelOpen:<path>`. Solves the "close in A also closes B"
@@ -122,6 +125,11 @@ function makeDiffPanelContext() {
       }
     }
     if (!isOpen(projectPath)) writeOpen(projectPath, true);
+    // Tell the file tree to walk to this file (expand ancestors + scroll +
+    // brief highlight). One-way: openFile knows nothing about the tree's
+    // mounted state — if the Files tab isn't visible, the request goes
+    // unanswered, which is the documented v1 behavior under collapsed sidebar.
+    reveal.request(projectPath, rel);
   }
 
   /** Callers may register a disposer (e.g. editor-pty kill) to run whenever

--- a/src/context/reveal.tsx
+++ b/src/context/reveal.tsx
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  createSignal,
+  useContext,
+  type ParentProps,
+} from "solid-js";
+
+/** Cross-pane "reveal a file in the file tree" bus.
+ *
+ *  diffPanel.openFile (whether triggered from the Cmd+K palette, the file
+ *  tree itself, or future surfaces) calls `request(projectPath, rel)` with
+ *  the just-opened file. The FileTree component reacts via createEffect:
+ *  expand the chain of ancestor directories, scroll the row into view,
+ *  flash a transient highlight.
+ *
+ *  Each request gets a fresh monotonic `id`. The consumer tracks
+ *  `lastHandledId` and only acts on a higher one — that prevents the
+ *  handler self-triggering when it mutates other state and re-runs the
+ *  effect on the same pending payload.
+ */
+export type RevealRequest = {
+  projectPath: string;
+  rel: string;
+  id: number;
+};
+
+function makeRevealContext() {
+  let nextId = 1;
+  const [pending, setPending] = createSignal<RevealRequest | null>(null);
+
+  function request(projectPath: string, rel: string) {
+    setPending({ projectPath, rel, id: nextId++ });
+  }
+
+  return { pending, request };
+}
+
+const Ctx = createContext<ReturnType<typeof makeRevealContext>>();
+
+export function RevealProvider(props: ParentProps) {
+  const ctx = makeRevealContext();
+  return <Ctx.Provider value={ctx}>{props.children}</Ctx.Provider>;
+}
+
+export function useReveal() {
+  const v = useContext(Ctx);
+  if (!v) throw new Error("useReveal outside RevealProvider");
+  return v;
+}


### PR DESCRIPTION
Closes #13.

## Summary

- VS Code-style "reveal in tree": when a file is opened via `diffPanel.openFile` (today's only caller is the Cmd+K palette shipped in #11; tomorrow could be any future surface), the Files sidebar switches to the Files tab, expands every ancestor directory, scrolls the row into view, and flashes a brief indigo highlight that fades over ~1.2s.
- New `RevealProvider` (one-way pub/sub): `openFile` calls `reveal.request(projectPath, rel)`, consumers in `App.tsx` Shell and `<FileTree>` react. Each request gets a fresh monotonic id; consumers track `lastHandledId` to avoid re-firing on their own state mutations.
- New `expandTo(path)` in `use-file-tree.ts` — idempotent twin of `toggleDir`, lazy-loads children if needed, throws on load failure so the walk can bail mid-chain on transient races (deleted dir, permission, etc.).

## Notable design choices

- **Sidebar tab-switch in Shell, walk in FileTree.** First pass had both in `<FileTree>`, but `<SidebarPanel>` only mounts FileTree when the active tab is Files — so if the user picked from ⌘K while on Sessions, FileTree never mounted, never saw the reveal, never switched the tab. Splitting it: Shell (always mounted) flips the tab, FileTree (mounts after the flip) picks up the same pending request and runs the walk. The two effects compose naturally because `pending()` is a signal, not an event.
- **No `revealCtx.clear()` after handling.** Considered it for cleanliness but the lastHandledId guard already prevents re-processing, and not clearing means a tab-flip-out-and-back-in re-runs reveal on the most-recent file, which feels right (you switched away, switched back, you probably want to see where you were). If that turns out to be annoying we can add `clear()` later.
- **Two `requestAnimationFrame`s before scroll.** First settles the store mutation, second waits for `<For>` to materialize the new rows so `nodeRefs` has the leaf entry. Single rAF was missing the row about half the time on deeper expansions.
- **Cancellable highlight timer.** Holding the `setTimeout` handle so a *new* reveal can clear the prior timer — without it, the first reveal's expiration would wipe the second reveal's highlight as soon as it fires.
- **Ref map over `data-abs-path` querySelector.** Cleaner: TreeNode registers its button ref via a callback prop on mount/cleanup, FileTree keeps a `Map<absPath, HTMLElement>`. No `CSS.escape`, no DOM query racing the re-render.
- **No new deps. No PTY changes. No new Rust commands.**

## Known v1 limitation

- **Collapsed sidebar (⌘B): no-op.** The reveal request is dispatched but goes unanswered — we don't auto-uncollapse the sidebar, that's an explicit user choice. The file still opens in the diff panel; the tree just isn't there to react. If we ever decide collapsed should still queue the reveal for the next uncollapse, the path is to keep `pending` set and have `<SidebarPanel>`'s Show-trigger re-fire the consumers.

## Test plan

- [x] Sidebar on Sessions → ⌘K → pick a file deep in the tree → tab flips to Files, ancestors expand, row scrolls into view + highlight fades
- [x] Sidebar on Files → ⌘K → pick a file → expansion + scroll + highlight without tab flip
- [x] Pick file A → quickly pick file B → B's highlight isn't wiped by A's stale timer
- [x] File at project root (no ancestors) → highlight only, no walk
- [x] Sidebar collapsed → ⌘K → pick a file → file opens in diff panel, no visible tree change (documented)
- [x] Selecting a session from ⌘K is unaffected (no reveal request fires)
- [x] `bun run typecheck` clean
- [x] `cargo check` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)