### PR TITLE
feat(diff-panel): make preview tabs draggable into Claude PTY

### DIFF
--- a/src/components/diff-panel/diff-panel.tsx
+++ b/src/components/diff-panel/diff-panel.tsx
@@ -16,6 +16,7 @@ import { useGit } from "@/context/git";
 import { useOpenIn } from "@/context/open-in";
 import { useEditorPty } from "@/context/editor-pty";
 import { ContextMenu, type ContextMenuItem } from "@/components/context-menu";
+import { createInternalDrag } from "@/lib/use-internal-drag";
 import { DiffFileRow } from "./diff-file-row";
 import { FilePreview } from "./file-preview";
 import { EditorPtyView } from "./editor-pty-view";
@@ -338,6 +339,7 @@ function TabStrip(props: { projectPath: string }) {
             return (
               <TabItem
                 tab={t}
+                projectPath={props.projectPath}
                 active={isActive()}
                 onActivate={() => panel.setActiveTab(props.projectPath, key)}
                 onClose={() => panel.closeTab(props.projectPath, key)}
@@ -379,6 +381,10 @@ function TabStrip(props: { projectPath: string }) {
 
 function TabItem(props: {
   tab: PanelTab;
+  /** Project path used to resolve the tab's project-relative `path` to an
+   *  absolute path for the drag publisher (and for downstream @rel
+   *  conversion in `buildDropPayload`). */
+  projectPath: string;
   active: boolean;
   onActivate: () => void;
   onClose: () => void;
@@ -390,15 +396,41 @@ function TabItem(props: {
     return `${props.tab.editorId} ${basename(props.tab.path)}`;
   };
 
+  // Drag publisher: file/editor tabs carry a `rel` path; the diff tab does
+  // not and returns null so the drag never starts on it. Absolute path is
+  // computed inline so we don't bind to a stale projectPath.
+  const drag = createInternalDrag(() => {
+    if (props.tab.kind === "diff") return null;
+    const base = props.projectPath.endsWith("/")
+      ? props.projectPath.slice(0, -1)
+      : props.projectPath;
+    return {
+      path: `${base}/${props.tab.path}`,
+      label: basename(props.tab.path),
+    };
+  });
+
+  function onClick(e: MouseEvent) {
+    if (drag.consumedClick()) {
+      e.preventDefault();
+      return;
+    }
+    props.onActivate();
+  }
+
   return (
     <div
+      onPointerDown={drag.handlers.onPointerDown}
+      onPointerMove={drag.handlers.onPointerMove}
+      onPointerUp={drag.handlers.onPointerUp}
+      onPointerCancel={drag.handlers.onPointerCancel}
       class={
         "group h-full min-w-0 flex items-center gap-1.5 px-3 text-[12px] cursor-default border-r border-neutral-800 transition " +
         (props.active
           ? "bg-neutral-900 text-neutral-100"
           : "text-neutral-400 hover:bg-neutral-900/60 hover:text-neutral-200")
       }
-      onClick={props.onActivate}
+      onClick={onClick}
       onContextMenu={props.onContextMenu}
     >
       <Switch>

--- a/src/components/file-tree/tree-node.tsx
+++ b/src/components/file-tree/tree-node.tsx
@@ -2,15 +2,8 @@ import { onCleanup, onMount, Show } from "solid-js";
 import { ChevronRight, Folder, FolderOpen } from "lucide-solid";
 import { iconForFile } from "@/lib/file-icon";
 import { BADGE_COLOR, BADGE_LETTER, type FileStatus } from "@/lib/git-status";
-import {
-  INTERNAL_DROP_EVENT,
-  type InternalDropDetail,
-  setHoverPtyId,
-  setInternalDragState,
-} from "@/lib/internal-drag";
+import { createInternalDrag } from "@/lib/use-internal-drag";
 import type { TreeNode as TreeNodeType } from "./use-file-tree";
-
-const DRAG_THRESHOLD_PX = 5;
 
 type Props = {
   node: TreeNodeType;
@@ -41,10 +34,6 @@ export function TreeNode(props: Props) {
   const fileIcon = () => iconForFile(props.node.name);
 
   let buttonRef: HTMLButtonElement | undefined;
-  let pressStart: { x: number; y: number } | null = null;
-  let dragging = false;
-  let didDrag = false;
-  let ghost: HTMLDivElement | null = null;
 
   onMount(() => {
     if (buttonRef) props.registerRef?.(props.node.path, buttonRef);
@@ -53,112 +42,14 @@ export function TreeNode(props: Props) {
     props.registerRef?.(props.node.path, null);
   });
 
-  function buildGhost(label: string): HTMLDivElement {
-    const el = document.createElement("div");
-    el.textContent = label;
-    el.style.cssText = [
-      "position:fixed",
-      "pointer-events:none",
-      "z-index:9999",
-      "padding:4px 8px",
-      "border-radius:6px",
-      "background:rgba(79,70,229,0.92)",
-      "color:#fff",
-      "font-size:12px",
-      "font-family:ui-sans-serif,system-ui",
-      "box-shadow:0 4px 10px rgba(0,0,0,0.3)",
-      "transform:translate(10px,10px)",
-      "max-width:260px",
-      "overflow:hidden",
-      "text-overflow:ellipsis",
-      "white-space:nowrap",
-    ].join(";");
-    return el;
-  }
-
-  function cleanup() {
-    ghost?.remove();
-    ghost = null;
-    dragging = false;
-    pressStart = null;
-    setInternalDragState(null);
-    setHoverPtyId(null);
-  }
-
-  function onPointerDown(e: PointerEvent) {
-    if (e.button !== 0) return;
-    pressStart = { x: e.clientX, y: e.clientY };
-    didDrag = false;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }
-
-  function onPointerMove(e: PointerEvent) {
-    if (!pressStart) return;
-    if (!dragging) {
-      const dx = e.clientX - pressStart.x;
-      const dy = e.clientY - pressStart.y;
-      if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return;
-      dragging = true;
-      didDrag = true;
-      ghost = buildGhost(props.node.name);
-      document.body.appendChild(ghost);
-      setInternalDragState({ path: props.node.path, name: props.node.name });
-    }
-    if (ghost) {
-      ghost.style.left = `${e.clientX}px`;
-      ghost.style.top = `${e.clientY}px`;
-    }
-    // Update the drop target highlight. elementFromPoint returns the
-    // topmost CSS-painted element under the coords; walk up to find
-    // whichever terminal host is advertising its pty id.
-    const under = document.elementFromPoint(e.clientX, e.clientY);
-    const host =
-      under instanceof Element
-        ? under.closest<HTMLElement>("[data-pty-id]")
-        : null;
-    setHoverPtyId(host?.dataset.ptyId ?? null);
-  }
-
-  function onPointerUp(e: PointerEvent) {
-    if (!pressStart) {
-      cleanup();
-      return;
-    }
-    if (dragging) {
-      const under = document.elementFromPoint(e.clientX, e.clientY);
-      const host =
-        under instanceof Element
-          ? under.closest<HTMLElement>("[data-pty-id]")
-          : null;
-      const kind = host?.dataset.ptyKind;
-      const ptyId = host?.dataset.ptyId;
-      if (host && (kind === "claude" || kind === "shell") && ptyId) {
-        const detail: InternalDropDetail = {
-          ptyKind: kind,
-          ptyId,
-          path: props.node.path,
-        };
-        window.dispatchEvent(
-          new CustomEvent<InternalDropDetail>(INTERNAL_DROP_EVENT, { detail }),
-        );
-      }
-    }
-    try {
-      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-    } catch {
-      // ignore — capture may have been lost
-    }
-    cleanup();
-    // The click event fires right after pointerup; let the flag linger
-    // one frame so onClick can read it and skip the select/toggle.
-    requestAnimationFrame(() => {
-      didDrag = false;
-    });
-  }
+  const drag = createInternalDrag(() => ({
+    path: props.node.path,
+    label: props.node.name,
+  }));
 
   function onClick(e: MouseEvent) {
     e.preventDefault();
-    if (didDrag) return;
+    if (drag.consumedClick()) return;
     if (props.onModClick?.(e, props.node.path, props.node.isDir)) return;
     props.onSelect(props.node.path);
     if (props.node.isDir) {
@@ -184,10 +75,10 @@ export function TreeNode(props: Props) {
   return (
     <button
       ref={buttonRef}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={cleanup}
+      onPointerDown={drag.handlers.onPointerDown}
+      onPointerMove={drag.handlers.onPointerMove}
+      onPointerUp={drag.handlers.onPointerUp}
+      onPointerCancel={drag.handlers.onPointerCancel}
       onClick={onClick}
       onDblClick={onDblClick}
       onKeyDown={onKeyDown}

--- a/src/lib/use-internal-drag.ts
+++ b/src/lib/use-internal-drag.ts
@@ -1,0 +1,167 @@
+// Pointer-based custom drag for "publish a file path to a Claude / shell PTY".
+// Used by the file tree (rows) and the diff-panel preview (tabs).
+//
+// Why custom instead of HTML5 drag: Tauri's `dragDropEnabled: true` lets the
+// NSView capture every drag before the webview sees it (needed so OS Finder
+// drops still work). HTML5 dragstart never fires inside the webview. Pointer
+// events bypass that capture cleanly.
+//
+// Contract: caller supplies a `source()` accessor returning the absolute
+// path + a display label (or null when this row/tab isn't draggable, e.g.
+// the "Git changes" diff tab). The hook owns ghost rendering, threshold
+// detection, hover-target tracking, and drop dispatch via the shared
+// INTERNAL_DROP_EVENT bus consumed in App.tsx.
+
+import {
+  INTERNAL_DROP_EVENT,
+  type InternalDropDetail,
+  setHoverPtyId,
+  setInternalDragState,
+} from "@/lib/internal-drag";
+
+const DRAG_THRESHOLD_PX = 5;
+
+export type InternalDragSource = () => { path: string; label: string } | null;
+
+function buildGhost(label: string): HTMLDivElement {
+  const el = document.createElement("div");
+  el.textContent = label;
+  el.style.cssText = [
+    "position:fixed",
+    "pointer-events:none",
+    "z-index:9999",
+    "padding:4px 8px",
+    "border-radius:6px",
+    "background:rgba(79,70,229,0.92)",
+    "color:#fff",
+    "font-size:12px",
+    "font-family:ui-sans-serif,system-ui",
+    "box-shadow:0 4px 10px rgba(0,0,0,0.3)",
+    "transform:translate(10px,10px)",
+    "max-width:260px",
+    "overflow:hidden",
+    "text-overflow:ellipsis",
+    "white-space:nowrap",
+  ].join(";");
+  return el;
+}
+
+export function createInternalDrag(source: InternalDragSource) {
+  let pressStart: { x: number; y: number } | null = null;
+  let dragging = false;
+  let didDrag = false;
+  let ghost: HTMLDivElement | null = null;
+
+  function cleanup() {
+    ghost?.remove();
+    ghost = null;
+    dragging = false;
+    pressStart = null;
+    setInternalDragState(null);
+    setHoverPtyId(null);
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.button !== 0) return;
+    pressStart = { x: e.clientX, y: e.clientY };
+    didDrag = false;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!pressStart) return;
+    if (!dragging) {
+      const dx = e.clientX - pressStart.x;
+      const dy = e.clientY - pressStart.y;
+      if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return;
+      const s = source();
+      if (!s) {
+        // Caller declined to drag — abort the gesture without a ghost.
+        pressStart = null;
+        return;
+      }
+      dragging = true;
+      didDrag = true;
+      ghost = buildGhost(s.label);
+      document.body.appendChild(ghost);
+      setInternalDragState({ path: s.path, name: s.label });
+    }
+    if (ghost) {
+      ghost.style.left = `${e.clientX}px`;
+      ghost.style.top = `${e.clientY}px`;
+    }
+    // Update the drop target highlight. elementFromPoint returns the
+    // topmost CSS-painted element under the coords; walk up to find
+    // whichever terminal host is advertising its pty id.
+    const under = document.elementFromPoint(e.clientX, e.clientY);
+    const host =
+      under instanceof Element
+        ? under.closest<HTMLElement>("[data-pty-id]")
+        : null;
+    setHoverPtyId(host?.dataset.ptyId ?? null);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!pressStart) {
+      cleanup();
+      return;
+    }
+    if (dragging) {
+      const s = source();
+      if (s) {
+        const under = document.elementFromPoint(e.clientX, e.clientY);
+        const host =
+          under instanceof Element
+            ? under.closest<HTMLElement>("[data-pty-id]")
+            : null;
+        const kind = host?.dataset.ptyKind;
+        const ptyId = host?.dataset.ptyId;
+        if (host && (kind === "claude" || kind === "shell") && ptyId) {
+          const detail: InternalDropDetail = {
+            ptyKind: kind,
+            ptyId,
+            path: s.path,
+          };
+          window.dispatchEvent(
+            new CustomEvent<InternalDropDetail>(INTERNAL_DROP_EVENT, {
+              detail,
+            }),
+          );
+        }
+      }
+    }
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore — capture may have been lost
+    }
+    cleanup();
+    // The click event fires right after pointerup; let the flag linger
+    // one frame so onClick can read it via consumedClick() and skip its
+    // default behavior.
+    requestAnimationFrame(() => {
+      didDrag = false;
+    });
+  }
+
+  function onPointerCancel() {
+    cleanup();
+  }
+
+  /** True between pointerup and the next animation frame when the gesture
+   *  was actually a drag (not a click). Caller's onClick should bail when
+   *  this is true so a tab activation / row select doesn't fire on drop. */
+  function consumedClick(): boolean {
+    return didDrag;
+  }
+
+  return {
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+    },
+    consumedClick,
+  };
+}


### PR DESCRIPTION
Closes #12.

## Summary

- File and editor tabs in the diff-panel TabStrip now drag the same way file-tree rows already did. Drop on a Claude or shell PTY → `@rel ` lands in the target terminal via the existing `INTERNAL_DROP_EVENT` bus + `buildDropPayload` round-trip in `App.tsx`.
- Closes the workflow loop the Cmd+K palette opened (#11): ⌘K → file lands in preview → drag tab into Claude → continue typing. Before this, the user had to bounce back to the sidebar tree to re-find the file just to drag from it.
- "Git changes" tab (the kind: "diff" pseudo-tab) is intentionally not draggable — its `source()` returns `null`.

## Notable design choices

- **Hook extraction.** The ~110 LoC pointer drag block in `tree-node.tsx` was duplicated nowhere — adding it to TabItem would have made it duplicated everywhere. Pulled into `src/lib/use-internal-drag.ts` as `createInternalDrag(source)`. The hook owns threshold detection (5px), ghost rendering, hover-target tracking, drop dispatch, and a `consumedClick()` accessor for the post-drag click suppression. Caller passes a `() => { path, label } | null` accessor — null means "not draggable this time" so a row/tab can opt out without conditional handler binding.
- **Click vs drag suppression.** Same trick the file tree already used: drag flag lingers one rAF after `pointerup` so the click event that fires immediately after can read it via `consumedClick()` and bail. Tab activation only fires on actual clicks.
- **Absolute path computed inline in TabItem's source accessor**, not captured eagerly. The tab carries `rel`; the projectPath comes from props; computing on every drag-start avoids stale closures if Solid ever decides to reuse the row across tab reorders.
- **No new deps.** No PTY changes. No Rust changes. No context changes. Purely UI + one new util file.

## Test plan

- [x] **Regression**: drag from file-tree row to a Claude PTY → `@rel ` lands as before
- [x] **New**: file tab in preview → drag onto Claude PTY → `@rel ` lands the same way
- [x] **New**: editor tab (e.g. nvim/helix opened from a file) → drag onto Claude PTY → `@rel ` lands
- [x] **Negative**: Git changes tab is not draggable (no ghost appears on press-and-move)
- [x] **Click vs drag**: short click on a tab still activates it; drag (>5px) does not also activate
- [x] Drop on shell terminal (⌘J) also works (same bus)
- [x] `bun run typecheck` clean
- [x] `cargo check` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)