### PR TITLE
feat(diff-panel): refresh button in Git changes header

### DIFF
--- a/src/components/diff-panel/diff-panel.tsx
+++ b/src/components/diff-panel/diff-panel.tsx
@@ -5,6 +5,7 @@ import {
   FileText,
   FolderOpen,
   GitBranch,
+  RotateCw,
   Terminal as TerminalIcon,
   X,
   XCircle,
@@ -123,6 +124,22 @@ export function DiffPanel(props: Props) {
                     Split
                   </button>
                 </div>
+                <button
+                  onClick={() => void git.refresh(props.projectPath)}
+                  disabled={!!git.store[props.projectPath]?.loading}
+                  class="w-6 h-6 rounded flex items-center justify-center text-neutral-400 hover:text-neutral-100 hover:bg-neutral-800/80 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Refresh"
+                >
+                  <RotateCw
+                    size={13}
+                    strokeWidth={2}
+                    class={
+                      git.store[props.projectPath]?.loading
+                        ? "animate-spin"
+                        : ""
+                    }
+                  />
+                </button>
                 <button
                   onClick={toggleAll}
                   class="w-6 h-6 rounded flex items-center justify-center text-neutral-400 hover:text-neutral-100 hover:bg-neutral-800/80 transition"

--- a/src/context/git.tsx
+++ b/src/context/git.tsx
@@ -137,6 +137,17 @@ function makeGitContext() {
     });
   }
 
+  /** Manual refetch of git_status + git_summary. Skips if a fetch is already
+   *  in flight (the in-flight call already produces fresh data on completion).
+   *  Used by the Git changes panel header refresh button — needed because
+   *  some external commits (`git commit` from another process, `opencommit`,
+   *  etc.) only touch `.git/` internals that our fs-watcher's `is_relevant`
+   *  filter drops on purpose to avoid debouncer spam. */
+  async function refresh(projectPath: string): Promise<void> {
+    if (store[projectPath]?.loading) return;
+    await fetchNow(projectPath);
+  }
+
   onCleanup(() => {
     for (const [, un] of unlisteners) un();
     for (const [, t] of timers) window.clearTimeout(t);
@@ -146,6 +157,7 @@ function makeGitContext() {
 
   return {
     ensureFor,
+    refresh,
     statusFor,
     summaryFor,
     statusByAbsPath,


### PR DESCRIPTION
Closes #16.

## Summary

- New `RotateCw` icon button in the Git changes panel header (between the Unified|Split toggle and the expand-all toggle). Click → re-runs `git_status` + `git_summary` for the active project.
- Fixes the stale-panel symptom when external tools (`opencommit`, `git commit` in another shell, GUI clients) make the commit: those commits often only touch `.git/` internals that our fs-watcher's `is_relevant` filter drops on purpose to keep debouncer spam down (`fs.rs:180-213`), so the panel was otherwise frozen on the pre-commit state until something else triggered a refetch (project switch, file save).

## Notable design choices

- **Idempotent**. The `loading` flag was already on the git store entry, populated by `fetchNow`. The new public `refresh(projectPath)` wrapper just early-returns when `loading === true`, so a second click during an in-flight fetch is a no-op rather than a stacked race. The button itself is also `disabled` during loading and cursor-not-allowed-styled, so the user gets immediate visual feedback.
- **Spinner reuses the existing `animate-spin`**, same pattern the Files sidebar's RotateCw uses.
- **No `fetchNow` rename**. Kept the private function name; added a public `refresh` wrapper. Less churn in case anything else in the context picks up `fetchNow` later.
- **No new deps. No Rust changes. No new commands.** Two-file diff.

## Test plan

- [x] Open a project with changes → button visible between Unified|Split and the expand-all toggle, tooltip "Refresh"
- [x] Click → spinner spins briefly, list re-fetches, +/− counts update
- [x] While loading: button is disabled (opacity-50, cursor-not-allowed)
- [x] **Original bug repro**: make a commit in another terminal (`git commit -m '…'` or `opencommit`) → panel stays stale → click refresh → panel updates without project switch
- [x] `bun run typecheck` clean
- [x] `cargo check` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)