### PR TITLE
feat(terminal): scroll-to-bottom button + ⌘↓ shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import {
   computePanelLayout,
 } from "@/lib/panel-layout";
 import { ShellTerminalPanel } from "@/components/shell-terminal/shell-terminal-panel";
+import { requestScrollToBottom } from "@/lib/terminal-scroll-bus";
 import { displayLabel } from "@/lib/session-label";
 
 const AUTO_RESUME_FAIL_WINDOW_MS = 2000;
@@ -315,6 +316,23 @@ function Shell() {
           void shellPty.openTab(p);
         } else {
           void openNewTab();
+        }
+        return;
+      }
+      // Cmd+Down: scroll the terminal under the user's focus to its tail.
+      // Same shell-dock disambiguation as Cmd+T — focus inside the dock hits
+      // the active shell PTY, otherwise the active Claude tab. Companion to
+      // the floating ScrollToBottomButton each terminal renders.
+      if (mod && !e.shiftKey && !e.altKey && e.key === "ArrowDown") {
+        e.preventDefault();
+        const inShellDock =
+          document.activeElement instanceof Element &&
+          document.activeElement.closest("[data-shell-dock]") !== null;
+        if (inShellDock) {
+          const p = activeProjectPath();
+          if (p) requestScrollToBottom(shellPty.activeForProject(p));
+        } else {
+          requestScrollToBottom(term.store.activeTabId);
         }
         return;
       }

--- a/src/components/scroll-to-bottom-button.tsx
+++ b/src/components/scroll-to-bottom-button.tsx
@@ -1,0 +1,26 @@
+import { Show } from "solid-js";
+import { ChevronDown } from "lucide-solid";
+
+/** Floating bottom-right button that appears when the terminal viewport is
+ *  scrolled up from the tail. Click → scroll to bottom. Visibility is
+ *  controlled by the parent (driven by xterm's `onScroll` event). */
+export function ScrollToBottomButton(props: {
+  visible: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Show when={props.visible}>
+      <button
+        type="button"
+        class="absolute bottom-3 right-3 w-7 h-7 rounded-full bg-neutral-900/85 hover:bg-neutral-800 border border-neutral-700 text-neutral-300 hover:text-neutral-100 shadow-lg flex items-center justify-center transition backdrop-blur-sm z-10"
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onClick();
+        }}
+        title="Scroll to bottom (⌘↓)"
+      >
+        <ChevronDown size={14} strokeWidth={2.25} />
+      </button>
+    </Show>
+  );
+}

--- a/src/components/shell-terminal/shell-terminal-view.tsx
+++ b/src/components/shell-terminal/shell-terminal-view.tsx
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -10,6 +10,11 @@ import {
 } from "@tauri-apps/plugin-clipboard-manager";
 import { useShellPty } from "@/context/shell-pty";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
+import {
+  registerTerminalScroller,
+  unregisterTerminalScroller,
+} from "@/lib/terminal-scroll-bus";
+import { ScrollToBottomButton } from "@/components/scroll-to-bottom-button";
 
 const THEME = {
   background: "#0b0b0c",
@@ -51,8 +56,15 @@ export function ShellTerminalView(props: Props) {
   let resizeObs: ResizeObserver | undefined;
   let detachData: (() => void) | undefined;
   let detachExit: (() => void) | undefined;
+  let scrollDisposable: { dispose: () => void } | undefined;
   let fitDebounce: number | undefined;
   let disposed = false;
+
+  const [isScrolledUp, setIsScrolledUp] = createSignal(false);
+
+  function scrollToBottom() {
+    term?.scrollToBottom();
+  }
 
   const encoder = new TextEncoder();
 
@@ -158,6 +170,13 @@ export function ShellTerminalView(props: Props) {
       return true;
     });
 
+    scrollDisposable = term.onScroll(() => {
+      if (!term || disposed) return;
+      const buf = term.buffer.active;
+      setIsScrolledUp(buf.viewportY < buf.baseY);
+    });
+    registerTerminalScroller(props.ptyId, scrollToBottom);
+
     detachData = ctx.onData(props.ptyId, (bytes) => {
       if (disposed) return;
       try {
@@ -221,6 +240,8 @@ export function ShellTerminalView(props: Props) {
     if (fitDebounce) window.clearTimeout(fitDebounce);
     detachData?.();
     detachExit?.();
+    scrollDisposable?.dispose();
+    unregisterTerminalScroller(props.ptyId);
     try {
       term?.dispose();
     } catch (err) {
@@ -240,6 +261,10 @@ export function ShellTerminalView(props: Props) {
         ref={container}
         onContextMenu={(e) => e.preventDefault()}
         class="flex-1 min-h-0 min-w-0 overflow-hidden p-2"
+      />
+      <ScrollToBottomButton
+        visible={isScrolledUp()}
+        onClick={scrollToBottom}
       />
       <Show when={tab()?.error}>
         <div class="border-t border-red-900/50 bg-red-950/40 px-3 py-1.5 text-[11px] text-red-300 font-mono">

--- a/src/components/terminal-view.tsx
+++ b/src/components/terminal-view.tsx
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -13,6 +13,11 @@ import { useDiffPanel } from "@/context/diff-panel";
 import { makeFileLinkProvider } from "@/lib/xterm-file-links";
 import { hoverPtyId } from "@/lib/internal-drag";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
+import {
+  registerTerminalScroller,
+  unregisterTerminalScroller,
+} from "@/lib/terminal-scroll-bus";
+import { ScrollToBottomButton } from "@/components/scroll-to-bottom-button";
 
 const THEME = {
   background: "#0b0b0c",
@@ -56,7 +61,16 @@ export function TerminalView(props: Props) {
   let detachData: (() => void) | undefined;
   let detachExit: (() => void) | undefined;
   let linkDisposable: { dispose: () => void } | undefined;
+  let scrollDisposable: { dispose: () => void } | undefined;
   let fitDebounce: number | undefined;
+
+  // Drives the floating scroll-to-bottom button + reflects whether the user
+  // is currently reading scrollback. Updated from xterm's onScroll event.
+  const [isScrolledUp, setIsScrolledUp] = createSignal(false);
+
+  function scrollToBottom() {
+    term?.scrollToBottom();
+  }
 
   const encoder = new TextEncoder();
 
@@ -205,6 +219,17 @@ export function TerminalView(props: Props) {
       return true;
     });
 
+    // Track scroll position so the floating "scroll to bottom" button hides
+     // itself once the user is back at the tail. xterm fires onScroll for both
+     // user scrolling (wheel, drag) and new-data-pushed-baseY-down, so this
+     // signal also catches the "you have new content below" case.
+    scrollDisposable = term.onScroll(() => {
+      if (!term) return;
+      const buf = term.buffer.active;
+      setIsScrolledUp(buf.viewportY < buf.baseY);
+    });
+    registerTerminalScroller(props.id, scrollToBottom);
+
     detachData = ctx.onData(props.id, (bytes) => {
       term?.write(bytes);
     });
@@ -301,6 +326,8 @@ export function TerminalView(props: Props) {
     detachData?.();
     detachExit?.();
     linkDisposable?.dispose();
+    scrollDisposable?.dispose();
+    unregisterTerminalScroller(props.id);
     term?.dispose();
     // NOTE: intentionally NOT calling ctx.closeTab here — unmounting the view
     // (e.g. changing project) is separate from killing the PTY. The shell owns
@@ -323,6 +350,10 @@ export function TerminalView(props: Props) {
       data-pty-id={props.id}
     >
       <div ref={container} class="flex-1 min-h-0 min-w-0 overflow-hidden p-2" />
+      <ScrollToBottomButton
+        visible={isScrolledUp()}
+        onClick={scrollToBottom}
+      />
       <Show when={isDragOver()}>
         <div class="absolute inset-1 border-2 border-dashed border-indigo-400/60 rounded pointer-events-none flex items-center justify-center">
           <div class="px-3 py-1.5 rounded bg-indigo-500/20 text-indigo-200 text-[12px] font-medium">

--- a/src/lib/terminal-scroll-bus.ts
+++ b/src/lib/terminal-scroll-bus.ts
@@ -1,0 +1,29 @@
+// Tiny module-level registry that lets non-terminal surfaces (e.g. App.tsx's
+// global ⌘↓ keymap) ask a specific terminal to scroll its viewport to the
+// tail. Each xterm-hosting component (claude PTY, shell PTY) registers its
+// own `scrollToBottom` callback on mount keyed by its PTY id; App.tsx calls
+// `requestScrollToBottom(id)` for the resolved active terminal.
+//
+// Module-level (not a Solid context) because:
+//   - terminal-view doesn't need reactivity here, just a callback handle
+//   - keeps App.tsx's keymap branch synchronous and free of context plumbing
+//
+// IDs are PTY ids (UUIDs), unique across both Claude and shell PTYs.
+
+const scrollers = new Map<string, () => void>();
+
+export function registerTerminalScroller(id: string, fn: () => void): void {
+  scrollers.set(id, fn);
+}
+
+export function unregisterTerminalScroller(id: string): void {
+  scrollers.delete(id);
+}
+
+/** Scrolls the terminal with the given PTY id to its tail. No-op if no
+ *  scroller is registered for that id (e.g. tab is unmounted). */
+export function requestScrollToBottom(id: string | null): void {
+  if (!id) return;
+  const fn = scrollers.get(id);
+  if (fn) fn();
+}


### PR DESCRIPTION
Closes #17.

## Summary

- Each xterm-hosting view (Claude PTY, shell PTY) now renders a small floating `ChevronDown` button in its bottom-right corner whenever the viewport is scrolled up from the tail. Click → scroll-to-tail. Auto-hides when the buffer is at the bottom.
- **⌘↓** globally hits the same action without leaving the keyboard. Same shell-dock disambiguation as ⌘T: focus inside `[data-shell-dock]` targets the active shell PTY, otherwise the active Claude tab.
- Plumbing: tiny module-level registry in `src/lib/terminal-scroll-bus.ts` keyed by PTY id. terminal-view registers / unregisters its `scrollToBottom` callback on mount/cleanup; App.tsx calls `requestScrollToBottom(id)` for the resolved target.
- Reusable `<ScrollToBottomButton>` component shared by both surfaces.

## Notable design choices

- **One signal, no manual hide.** Each terminal subscribes to xterm's `onScroll` and tracks `viewportY < baseY`. Clicking the button calls `term.scrollToBottom()`, which fires `onScroll`, which updates the signal, which hides the button. Same path also covers the "new content arrived while you were scrolled up" case — baseY moves past viewportY and the button reappears as a "there's something below" hint, which is the right default behavior (not auto-scrolling on incoming data is the existing rule and we're keeping it).
- **Module-level registry, not a Solid context.** Two terminals, one keymap, no reactivity needed for this — a `Map<id, () => void>` with three exports beats a context provider for the cost.
- **Disambiguation reuses the existing `[data-shell-dock]` marker** that ⌘T already uses (`App.tsx:307-318`). Identical pattern, no new conventions.
- **Doesn't fix the underlying viewport-scrolls-up-unexpectedly bug** that motivated the issue. That's a separate root-cause investigation — likely tangled with the staggered fit / ResizeObserver cycle from #8. The button + shortcut are a permanent UX win regardless, exactly the way Warp keeps theirs forever.
- **No new deps.** No PTY changes. No Rust changes. Two new small files (~50 LoC total), three lightly-touched ones.

## Test plan

- [x] **Claude PTY**: scroll up via mouse wheel → button appears bottom-right → click → scroll snaps to tail, button vanishes
- [x] **Shell PTY**: same behavior in the dock terminal
- [x] **⌘↓ from Claude PTY focus**: scrolls the active Claude tab
- [x] **⌘↓ from shell dock focus**: scrolls the active shell PTY (not the Claude tab)
- [x] **New PTY data while scrolled up**: button stays visible (baseY > viewportY) — works as a "you have new lines below" indicator
- [x] **Tab switch while scrolled up + back**: button respects the new tab's own scroll state, not stale across tabs
- [x] `bun run typecheck` clean
- [x] `cargo check` + `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)