### PR TITLE
fix(tabs): keep close-tab fallback within the same project (#20)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -855,7 +855,14 @@ function Shell() {
                     );
                   }}
                 </For>
-                <Show when={activeProjectPath() && projectTabs().length === 0}>
+                <Show
+                  when={
+                    activeProjectPath() &&
+                    (projectTabs().length === 0 ||
+                      !activeTab() ||
+                      activeTab()?.projectPath !== activeProjectPath())
+                  }
+                >
                   <div class="absolute inset-0 flex items-center justify-center text-neutral-500 text-sm">
                     Pick a session or start a new one.
                   </div>

--- a/src/context/terminal.tsx
+++ b/src/context/terminal.tsx
@@ -154,13 +154,24 @@ export function makeTerminalContext() {
       produce((s) => {
         const idx = s.tabs.findIndex((t) => t.id === id);
         if (idx < 0) return;
+        const closed = s.tabs[idx];
         s.tabs.splice(idx, 1);
         if (s.activeTabId === id) {
-          if (s.tabs.length === 0) {
+          // Pick the nearest sibling in the SAME project (prefer left, then
+          // right). Falling back to the global tab list lands on a foreign
+          // project's tab, leaving the active project's pane blank — see #20.
+          const siblings: { tab: TerminalTab; pos: number }[] = [];
+          s.tabs.forEach((t, i) => {
+            if (t.projectPath === closed.projectPath) {
+              siblings.push({ tab: t, pos: i });
+            }
+          });
+          if (siblings.length === 0) {
             s.activeTabId = null;
           } else {
-            const next = Math.max(0, idx - 1);
-            s.activeTabId = s.tabs[Math.min(next, s.tabs.length - 1)].id;
+            const prev = [...siblings].reverse().find((x) => x.pos < idx);
+            const next = siblings.find((x) => x.pos >= idx);
+            s.activeTabId = (prev ?? next ?? siblings[0]).tab.id;
           }
         }
       }),


### PR DESCRIPTION
## Summary
- Closes #20. `closeTab` in `src/context/terminal.tsx` now picks the next active tab from siblings sharing the closing tab's `projectPath` (prefer left, fall back to right), matching the shell-dock's existing behavior in `src/context/shell-pty.tsx:141-163`.
- Adds a defense-in-depth in `src/App.tsx`: the central column's empty-state copy also renders when `activeTabId` points at a foreign-project tab, so any future code path that mishandles the active id won't reproduce the black-void symptom.

## Test plan
- [x] Project A with one Claude tab (A1). Open project B, start B1. Switch back to A and open A2. Close A2 → should activate A1 (no black screen).
- [x] Same setup, close A1 first instead of A2 → A2 stays active, no flicker.
- [x] Close the only tab in a project → empty-state "Pick a session or start a new one." renders; auto-resume effect can still trigger on next project switch.
- [x] Close a middle tab in a project with three (A1, A2, A3 with A2 active) → A1 is picked (prefer left).
- [x] Close the leftmost tab when no left sibling exists in the same project → right sibling is picked.
- [x] `bun run typecheck` clean.
- [x] Sanity: shell-dock close behavior unchanged (different store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)