### PR TITLE
fix(notifications): drop idle_prompt events server-side

### DIFF
--- a/PRPs/012--osc777-cli-agent-events.md
+++ b/PRPs/012--osc777-cli-agent-events.md
@@ -123,8 +123,16 @@ const SENTINEL: &str = "warp://cli-agent";
 `feed(&mut self, chunk: &[u8]) -> Vec<CliAgentEvent>` — does not
 consume `chunk`; the caller still forwards it to xterm.js.
 
-Rust-side filter: drop `event == "stop"` before returning, so the
-frontend never has to know JSONL is the canonical source.
+Rust-side filter drops two event types before returning, so the
+frontend never has to know about them:
+
+- `stop` — JSONL watcher is the canonical source for turn-completion.
+- `idle_prompt` — Claude fires this every 60s while the prompt sits
+  empty, *including while the user is reading transcript output*.
+  In practice this is noise; the actually-blocked case is already
+  covered by `permission_request`. Dropped post-v1.5.0 after live
+  feedback that the toast was firing while the user was reading
+  Claude's diff output.
 
 `tool_input_preview` extraction mirrors warp's logic
 ([`v1.rs:29-34`](https://github.com/warpdotdev/warp/blob/main/app/src/terminal/cli_agent_sessions/event/v1.rs#L29-L34)):

--- a/README.md
+++ b/README.md
@@ -98,19 +98,13 @@ under `~/.claude/projects/` and notifies you whenever a session ends
 its turn. This works for every Claude session you run inside Klaudio,
 no extra setup needed.
 
-### Richer events (optional warp plugin)
+### Permission requests (optional warp plugin)
 
-The transcript watcher is blind to two events that never get written
-to disk:
-
-- **`permission_request`** — Claude wants to run a tool (Bash, Edit,
-  etc.) that requires your approval.
-- **`idle_prompt`** — Claude has been waiting on you and is nudging
-  for input.
-
-To catch these, install the [warp Claude Code
-plugin](https://github.com/warpdotdev/claude-code-warp). It emits
-[OSC 777 sidechannel events](https://github.com/warpdotdev/warp/blob/main/app/src/terminal/cli_agent_sessions/event/v1.rs)
+The transcript watcher cannot see when Claude wants to run a tool
+(`Bash`, `Edit`, etc.) that requires your approval — that signal
+never gets written to disk. To catch those, install the [warp Claude
+Code plugin](https://github.com/warpdotdev/claude-code-warp). It
+emits [OSC 777 sidechannel events](https://github.com/warpdotdev/warp/blob/main/app/src/terminal/cli_agent_sessions/event/v1.rs)
 that Klaudio Panels parses out of the PTY stream. The same plugin
 also works in [warp.app](https://www.warp.dev/) and any other terminal
 that speaks the `warp://cli-agent` protocol — install once, get
@@ -123,9 +117,14 @@ claude plugin install warp@claude-code-warp
 ```
 
 Restart your Claude session afterwards so the plugin loads. From then
-on, Klaudio Panels will surface a more attention-grabbing chime + a
-banner for permission requests and idle prompts on top of the
-built-in turn-completion notifications.
+on, permission requests get a more attention-grabbing chime + a
+banner on top of the built-in turn-completion notifications.
+
+> The plugin also emits an `idle_prompt` event every 60s while the
+> Claude prompt sits empty (which fires while you're *reading*
+> output too). Klaudio drops it server-side because it's noise, not
+> signal — `permission_request` already covers the actually-blocked
+> case.
 
 > Why this approach? Klaudio's [non-negotiable
 > rule #2](./CLAUDE.md) is to never parse Claude's terminal

--- a/src-tauri/src/cli_agent.rs
+++ b/src-tauri/src/cli_agent.rs
@@ -153,7 +153,7 @@ impl Osc777Sniffer {
 
     /// Consume `self.body` (already collected between OSC start and
     /// terminator) and return the parsed event if it carries our
-    /// sentinel and is not a `stop` (JSONL is canonical for `stop`).
+    /// sentinel and survives the server-side drop list.
     fn finalize(&mut self) -> Option<CliAgentEvent> {
         let body = std::mem::take(&mut self.body);
         let raw = std::str::from_utf8(&body).ok()?;
@@ -163,9 +163,14 @@ impl Osc777Sniffer {
         }
         let parsed: RawEvent = serde_json::from_str(json_body).ok()?;
 
-        // JSONL watcher is the canonical source for turn-completion;
-        // dropping `stop` here keeps the frontend from having to dedup.
-        if parsed.event == "stop" {
+        // Dropped server-side so the frontend never has to filter:
+        // - `stop`: JSONL watcher is the canonical source.
+        // - `idle_prompt`: Claude fires it every 60s when the prompt
+        //   sits empty, including while the user is *reading* the
+        //   transcript. In practice this is noise, not signal — the
+        //   actual blocked-on-user case is already covered by
+        //   `permission_request`.
+        if matches!(parsed.event.as_str(), "stop" | "idle_prompt") {
             return None;
         }
 
@@ -232,13 +237,13 @@ mod tests {
     }
 
     #[test]
-    fn parses_idle_prompt_st_terminator() {
-        let json = r#"{"v":1,"agent":"claude","event":"idle_prompt","query":"are you there?"}"#;
+    fn parses_permission_request_st_terminator() {
+        let json = r#"{"v":1,"agent":"claude","event":"permission_request","tool_name":"Bash"}"#;
         let mut s = Osc777Sniffer::new();
         let events = s.feed(&frame_st(json));
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event, "idle_prompt");
-        assert_eq!(events[0].query.as_deref(), Some("are you there?"));
+        assert_eq!(events[0].event, "permission_request");
+        assert_eq!(events[0].tool_name.as_deref(), Some("Bash"));
     }
 
     #[test]
@@ -276,6 +281,17 @@ mod tests {
     }
 
     #[test]
+    fn drops_idle_prompt_event() {
+        // Claude fires this every 60s while the prompt is empty —
+        // including while the user is reading transcript output.
+        // Drop server-side to keep the frontend quiet.
+        let json = r#"{"v":1,"agent":"claude","event":"idle_prompt","query":"still there?"}"#;
+        let mut s = Osc777Sniffer::new();
+        let events = s.feed(&frame_bel(json));
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
     fn ignores_wrong_sentinel() {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"\x1b]777;notify;klaudio-panels;");
@@ -303,7 +319,7 @@ mod tests {
         let mut s = Osc777Sniffer::new();
         assert!(s.feed(&bytes).is_empty());
         // sniffer recovers and parses a subsequent valid frame
-        let json = r#"{"v":1,"agent":"claude","event":"idle_prompt"}"#;
+        let json = r#"{"v":1,"agent":"claude","event":"permission_request"}"#;
         let events = s.feed(&frame_bel(json));
         assert_eq!(events.len(), 1);
     }
@@ -320,7 +336,7 @@ mod tests {
         let events = s.feed(&bytes);
         assert!(events.is_empty());
         // sniffer is back to Normal and can parse a fresh frame
-        let json = r#"{"v":1,"agent":"claude","event":"idle_prompt"}"#;
+        let json = r#"{"v":1,"agent":"claude","event":"permission_request"}"#;
         let after = s.feed(&frame_bel(json));
         assert_eq!(after.len(), 1);
     }
@@ -341,7 +357,7 @@ mod tests {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"\x1b]777;X");
         bytes.extend_from_slice(&frame_bel(
-            r#"{"v":1,"agent":"claude","event":"idle_prompt"}"#,
+            r#"{"v":1,"agent":"claude","event":"permission_request"}"#,
         ));
         let mut s = Osc777Sniffer::new();
         let events = s.feed(&bytes);
@@ -362,7 +378,7 @@ mod tests {
         // schema bump changes the shape, serde will fail and the event
         // is dropped. Document by demonstrating: a v2 with same fields
         // still parses today.
-        let json = r#"{"v":2,"agent":"claude","event":"idle_prompt"}"#;
+        let json = r#"{"v":2,"agent":"claude","event":"permission_request"}"#;
         let mut s = Osc777Sniffer::new();
         let events = s.feed(&frame_bel(json));
         assert_eq!(events.len(), 1);

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -40,7 +40,7 @@ type CliAgentEvent = {
   plugin_version: string | null;
 };
 
-export type ToastKind = "complete" | "permission" | "idle";
+export type ToastKind = "complete" | "permission";
 
 export type Toast = {
   id: number;
@@ -247,33 +247,18 @@ function makeNotificationsContext() {
   }
 
   function handleAgentEvent(payload: CliAgentEvent) {
-    if (
-      payload.event !== "permission_request" &&
-      payload.event !== "idle_prompt"
-    ) {
-      return;
-    }
+    // Only `permission_request` reaches the frontend — `stop` and
+    // `idle_prompt` are dropped server-side in cli_agent.rs.
+    if (payload.event !== "permission_request") return;
     const projectPath = resolver.resolveOpenProject(payload.cwd);
     if (!projectPath) return;
 
-    if (payload.event === "permission_request") {
-      playPermissionRequest();
-      const tool = payload.tool_name ?? "a tool";
-      const preview = payload.tool_input_preview;
-      const body = preview && preview.length > 0 ? `${tool}: ${preview}` : tool;
-      const title = `${projectName(projectPath)} · Claude needs permission`;
-      alertProject(projectPath, title, body, "permission");
-      return;
-    }
-
-    // idle_prompt
-    playTaskComplete();
-    const title = `${projectName(projectPath)} · Claude is waiting for you`;
-    const body =
-      payload.query && payload.query.length > 0
-        ? payload.query
-        : "Open Klaudio Panels.";
-    alertProject(projectPath, title, body, "idle");
+    playPermissionRequest();
+    const tool = payload.tool_name ?? "a tool";
+    const preview = payload.tool_input_preview;
+    const body = preview && preview.length > 0 ? `${tool}: ${preview}` : tool;
+    const title = `${projectName(projectPath)} · Claude needs permission`;
+    alertProject(projectPath, title, body, "permission");
   }
 
   return {


### PR DESCRIPTION
## Summary

The warp plugin emits `idle_prompt` every 60s while Claude's prompt sits empty — including while the user is reading Claude's transcript output. In live use after v1.5.0 this fires "Claude is waiting for you" toasts while the user is actively engaged with the session, which is the opposite of what they need.

Dropped server-side in \`cli_agent.rs\` alongside the existing \`stop\` filter; the frontend handler and the README mention go too. \`permission_request\` remains the only OSC event we surface — that's the actually-blocked case the warp plugin's \`Notification\` hook was useful for.

## Test plan

- [x] \`cargo test --lib cli_agent\` — 14 passing including new \`drops_idle_prompt_event\` test.
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`bun run typecheck\` clean.
- [ ] Live smoke: with the warp plugin still installed, leave Claude idle for 60+ seconds with the window focused on its session — no toast. Trigger \`permission_request\` (e.g. ask Claude to \`Write /tmp/foo\`) — toast still fires as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)