### PR TITLE
fix(notifications): per-channel kill switch + settings panel in bell (#36)

### DIFF
--- a/PRPs/015--notification-preferences.md
+++ b/PRPs/015--notification-preferences.md
@@ -87,6 +87,25 @@ The popover gains a two-mode shell:
   Header label switches to "Settings" with a left-arrow back to
   list mode.
 
+**Plugin-aware gating for Permission requests.** Without the warp
+plugin no `permission_request` events ever reach the frontend, so an
+enabled toggle would lie. Detection runs through a new Tauri command
+`is_warp_plugin_installed` (reads
+`~/.claude/plugins/installed_plugins.json`, checks for the
+`warp@claude-code-warp` key). State is seeded async on context
+mount and refreshed every time the settings view opens — covering
+the "I just installed the plugin" flow without forcing a Klaudio
+restart.
+
+When the plugin is missing:
+- The Permission row renders **disabled + visually OFF** regardless
+  of the persisted pref. The persisted pref is preserved so it
+  takes effect once the plugin is installed.
+- The helper text becomes "Requires the warp/claude-code-warp
+  plugin. **Install →**" — the link opens the README anchor
+  `#permission-requests-recommended-warp-plugin` in the system
+  browser via `tauri-plugin-opener`.
+
 Toggle row layout (compact, ~32px tall):
 
 ```
@@ -265,17 +284,20 @@ the first thing the reader sees in that section, with a one-line
 
 ## Known limitations
 
-- No "off because of plugin missing" hint in the Permission row.
-  Could detect plugin install state and show a soft warning, but
-  doing it well needs a backend command (see #36 out-of-scope).
 - Restoring defaults requires flipping each toggle individually.
   Cheap to add a "Reset" link if it comes up.
+- Plugin detection is filesystem-based — uninstalls done via
+  `claude plugin remove` are picked up the next time the settings
+  view opens, but a custom marketplace that installs the plugin
+  outside `~/.claude/plugins/installed_plugins.json` would falsely
+  show as missing.
 
 ## Out of scope (track separately)
 
-- Detecting warp plugin presence and surfacing a guided install
-  step inline (#36 follow-up).
 - Tighter focus-based suppression: when the project's tab is
   active in a focused window, don't emit `session:complete` even
   if the toggle is on (#36 follow-up).
 - Per-project mute / per-event severity.
+- A live `notify` watch on `installed_plugins.json` (right now we
+  re-check on settings-view open, which is enough for the
+  install-without-restart UX).

--- a/PRPs/015--notification-preferences.md
+++ b/PRPs/015--notification-preferences.md
@@ -1,0 +1,281 @@
+# PRP 015: Notification preferences (kill switch + sounds toggle)
+
+> **Version:** 1.0
+> **Created:** 2026-05-02
+> **Status:** Draft
+> **Tracks:** [#36](https://github.com/willywg/klaudio-panels/issues/36)
+> **Builds on:** [PRP 013 (in-app toasts)](013--in-app-toast-notifications.md), [PRP 014 (bell + hover-pause)](014--notification-bell-and-hover-pause.md)
+
+---
+
+## Goal
+
+Give the user a per-channel kill switch over Klaudio's notifications,
+exposed inline from the bell popover. Three toggles, persisted in
+`localStorage`, honored by the notifications context before any
+toast / bell entry / OS banner / sound is produced:
+
+- `notifySessionComplete` — `session:complete` events from the JSONL
+  watcher (the noisy one — see #36).
+- `notifyPermission` — `permission_request` events from the warp
+  plugin (OSC 777). The high-signal path; off by default no, but
+  available as an opt-out.
+- `playSounds` — chimes for both kinds.
+
+## Why
+
+`session:complete` is JSONL-driven and fires once per Claude
+`end_turn` (terminal `stop_reason`). In real agentic loops Claude
+reaches `end_turn` after every tool-free reply ("Commit X listo",
+"Typecheck passes", "Fix applied"), not just at "task done"
+moments. An external user without the warp plugin reported the bell
+filling with five "Claude is done" entries in a few seconds while
+they were actively reading the same project's transcript.
+
+The right long-term fix is to lean on `permission_request` (warp
+plugin) as the primary signal and downgrade `session:complete` to
+something quieter — but that's a behavior change with its own
+tradeoffs (#36 "out of scope" section). The immediate fix the user
+asked for is a kill switch, surfaced where the noise is.
+
+## What
+
+### Preferences module — `src/lib/notifications-prefs.ts` (new)
+
+```ts
+export type NotificationPrefs = {
+  notifySessionComplete: boolean; // default true
+  notifyPermission: boolean;      // default true
+  playSounds: boolean;            // default true
+};
+
+export function getPrefs(): NotificationPrefs;
+export function setPrefs(patch: Partial<NotificationPrefs>): void;
+```
+
+Persistence: a single `localStorage` key `notificationPrefs`
+holding the JSON object. Missing / malformed → defaults all-on.
+Pattern matches `lib/sidebar-prefs.ts` (try/catch around storage
+access, default fallbacks).
+
+### Notifications context — `src/context/notifications.tsx`
+
+- Hold a `prefs` signal seeded from `getPrefs()` on context
+  creation. Provide `prefs()` and `updatePrefs(patch)` through the
+  hook.
+- `updatePrefs` writes to `localStorage` via `setPrefs` AND updates
+  the signal so consumers re-render in the same tick.
+- `handleComplete(payload)`: bail early if `!prefs().notifySessionComplete`.
+  Sound is also gated on `prefs().playSounds`.
+- `handleAgentEvent(payload)` (only `permission_request` reaches
+  here): bail early if `!prefs().notifyPermission`. Sound gated on
+  `playSounds`.
+
+The gates apply at the *entry point*, not inside `alertProject`.
+That keeps `alertProject` semantics unchanged for any future caller
+and means a disabled channel produces zero side-effects (no bell,
+no ring, no toast, no banner).
+
+### Settings panel — `src/components/notification-bell.tsx`
+
+The popover gains a two-mode shell:
+
+- **List mode** (default): existing items + "Mark all read".
+  Header gains a small ⚙️ gear button on the right of the
+  "Notifications" label, opens the settings panel.
+- **Settings mode**: replaces the body with three toggle rows.
+  Header label switches to "Settings" with a left-arrow back to
+  list mode.
+
+Toggle row layout (compact, ~32px tall):
+
+```
+[Label                                          ] [switch]
+[muted helper text — one line                  ]
+```
+
+Three rows:
+
+1. **Task complete** — "Notify when Claude finishes a turn."
+2. **Permission requests** — "Notify when Claude needs permission
+   to use a tool. Requires the warp/claude-code-warp plugin."
+3. **Sounds** — "Play a chime with each notification."
+
+Switch: small pill toggle, ~36px wide, neutral track / accent fill
+on. No external dependency — keep it as a styled `<button>`
+toggling a class.
+
+### Success criteria
+
+- [ ] Disabling **Task complete** stops bell items / toasts /
+      banners / sounds for `session:complete` events. Re-enabling
+      restores them on the *next* event (no replay of suppressed
+      ones, by design).
+- [ ] Disabling **Permission requests** does the same for
+      `permission_request` events from the warp plugin.
+- [ ] Disabling **Sounds** silences both chimes; toasts / bell /
+      banner still appear when their channel is on.
+- [ ] Prefs survive Klaudio restart.
+- [ ] All-off keeps the app silent (no toasts, no bell entries, no
+      OS banners, no chimes) regardless of plugin state.
+- [ ] Defaults are all-on (preserves v1.6.0 behavior for users who
+      never open settings).
+- [ ] Bell popover layout: gear in header, back arrow in settings
+      mode, three toggles, "Mark all read" still present in list
+      mode.
+- [ ] Outside-click and Escape close the popover from either mode.
+- [ ] Tab through popover: gear/back focusable; toggles focusable;
+      keyboard activates them (Space/Enter).
+
+### Non-goals
+
+- A separate Settings page or window. Bell-local panel only.
+- Per-project mute. Global only — see #36 "out of scope".
+- Settings sync across devices (no cloud, no JSON export/import).
+- Custom sounds / volume control.
+- Changing default behavior — every toggle defaults to ON to keep
+  existing users in the same place.
+- Anything outside notifications (sidebar prefs, theme, etc.).
+
+## How
+
+### Step 1 — `src/lib/notifications-prefs.ts`
+
+```ts
+const KEY = "notificationPrefs";
+
+const DEFAULTS: NotificationPrefs = {
+  notifySessionComplete: true,
+  notifyPermission: true,
+  playSounds: true,
+};
+
+export function getPrefs(): NotificationPrefs {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<NotificationPrefs>;
+    return {
+      notifySessionComplete: parsed.notifySessionComplete ?? DEFAULTS.notifySessionComplete,
+      notifyPermission: parsed.notifyPermission ?? DEFAULTS.notifyPermission,
+      playSounds: parsed.playSounds ?? DEFAULTS.playSounds,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export function setPrefs(patch: Partial<NotificationPrefs>): void {
+  try {
+    const next = { ...getPrefs(), ...patch };
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    // ignore — storage is best-effort.
+  }
+}
+```
+
+Defensive `?? DEFAULTS.x` handles the case where a future field is
+added and a returning user has only the older subset.
+
+### Step 2 — wire into `notifications.tsx`
+
+Inside `makeNotificationsContext`:
+
+```ts
+const [prefs, setPrefsSignal] = createSignal<NotificationPrefs>(getPrefs());
+
+function updatePrefs(patch: Partial<NotificationPrefs>) {
+  setPrefs(patch);
+  setPrefsSignal(getPrefs());
+}
+```
+
+`handleComplete`:
+
+```ts
+function handleComplete(payload: SessionCompletePayload) {
+  if (!prefs().notifySessionComplete) return;
+  if (prefs().playSounds) playTaskComplete();
+  // ... existing alertProject call
+}
+```
+
+`handleAgentEvent`:
+
+```ts
+function handleAgentEvent(payload: CliAgentEvent) {
+  if (payload.event !== "permission_request") return;
+  if (!prefs().notifyPermission) return;
+  const projectPath = resolver.resolveOpenProject(payload.cwd);
+  if (!projectPath) return;
+  if (prefs().playSounds) playPermissionRequest();
+  // ... existing alertProject call
+}
+```
+
+Expose `prefs` and `updatePrefs` from the context's return object.
+
+### Step 3 — bell settings panel
+
+Pull the popover body into a small `view` signal: `"list" | "settings"`.
+Render the appropriate body inside the existing card:
+
+```tsx
+const [view, setView] = createSignal<"list" | "settings">("list");
+// Reset to list mode every time the popover opens, so a fresh
+// click-on-bell never lands on the settings tab.
+createEffect(() => { if (open()) setView("list"); });
+```
+
+`<NotificationHeader>`:
+- list mode: "Notifications" label + (optional "Mark all read") + ⚙️ button → setView("settings")
+- settings mode: ← back button + "Settings" label
+
+`<NotificationSettings>`:
+- For each toggle: row with label, helper text, and a `<ToggleSwitch>`.
+- `ToggleSwitch` reads `notifications.prefs().<key>` and calls
+  `notifications.updatePrefs({ <key>: !current })` on click.
+
+Reuse the existing `text-[12px]` / neutral palette so the panel
+visually belongs to the popover.
+
+### Step 4 — README
+
+Move the Notifications section's plugin recommendation up — make it
+the first thing the reader sees in that section, with a one-line
+"Recommended" call-out. Mention the new prefs panel briefly:
+"prefer no notifications? Bell → ⚙️."
+
+## Risks
+
+- **Toggle race with in-flight events.** A user disables Task
+  complete the same instant a `session:complete` lands. The signal
+  read inside `handleComplete` reflects the latest value (Solid is
+  synchronous on signal reads), so the disable wins. No bug, just
+  worth knowing.
+- **Existing `alertProject` callers.** Today only `handleComplete`
+  and `handleAgentEvent` call it. If a future call site is added,
+  it's exempt from the toggle by construction. That's intentional
+  — toggles describe *channels*, not the underlying primitive.
+- **Settings UI inside popover.** Outside-click handler must still
+  fire when the user clicks outside while in settings mode. Same
+  handler covers both modes (it's keyed off `wrapRef.contains`,
+  not the visible body).
+
+## Known limitations
+
+- No "off because of plugin missing" hint in the Permission row.
+  Could detect plugin install state and show a soft warning, but
+  doing it well needs a backend command (see #36 out-of-scope).
+- Restoring defaults requires flipping each toggle individually.
+  Cheap to add a "Reset" link if it comes up.
+
+## Out of scope (track separately)
+
+- Detecting warp plugin presence and surfacing a guided install
+  step inline (#36 follow-up).
+- Tighter focus-based suppression: when the project's tab is
+  active in a focused window, don't emit `session:complete` even
+  if the toggle is on (#36 follow-up).
+- Per-project mute / per-event severity.

--- a/README.md
+++ b/README.md
@@ -88,17 +88,19 @@ badge counting how many projects are waiting). All three are
 suppressed when you're already focused on the project the event came
 from — they only fire for **background** activity.
 
-There are two tiers, depending on whether you install the optional
-plugin:
+> 🔔 **Recommended: install the warp plugin first.** Without it,
+> Klaudio falls back to the noisier transcript-watcher path, which
+> fires once per Claude turn (often several times a minute on long
+> agentic work). With the plugin you get the cleaner
+> `permission_request` channel — Claude pings you only when it's
+> actually waiting for you. Five-second install, see [Permission
+> requests (recommended warp plugin)](#permission-requests-recommended-warp-plugin).
+>
+> Want to mute or change which channels notify you? Click the bell in
+> the titlebar → ⚙️ Settings — toggle Task complete, Permission
+> requests, and Sounds independently.
 
-### Built-in (zero-config)
-
-Out of the box, Klaudio Panels watches the Claude transcript files
-under `~/.claude/projects/` and notifies you whenever a session ends
-its turn. This works for every Claude session you run inside Klaudio,
-no extra setup needed.
-
-### Permission requests (optional warp plugin)
+### Permission requests (recommended warp plugin)
 
 The transcript watcher cannot see when Claude wants to run a tool
 (`Bash`, `Edit`, etc.) that requires your approval — that signal
@@ -119,6 +121,17 @@ claude plugin install warp@claude-code-warp
 Restart your Claude session afterwards so the plugin loads. From then
 on, permission requests get a more attention-grabbing chime + a
 banner on top of the built-in turn-completion notifications.
+
+### Built-in fallback (zero-config)
+
+Out of the box, Klaudio Panels watches the Claude transcript files
+under `~/.claude/projects/` and notifies you whenever a session ends
+its turn. This works for every Claude session you run inside Klaudio,
+no extra setup needed — but Claude reaches "end of turn" after every
+tool-free reply, which means several notifications per minute on
+busy work. The warp plugin (above) is the cleaner signal; this path
+is the safety net if you can't install it. You can also disable it
+entirely from the bell's ⚙️ Settings panel.
 
 > The plugin also emits an `idle_prompt` event every 60s while the
 > Claude prompt sits empty (which fires while you're *reading*

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fs;
 pub mod git;
 pub mod notify;
 pub mod open_in;
+pub mod plugins;
 pub mod pty;
 pub mod session_watcher;
 pub mod sessions;
@@ -141,6 +142,7 @@ pub fn run() {
             shell_install::uninstall_cli,
             notify::notify_native,
             notify::set_dock_badge,
+            plugins::is_warp_plugin_installed,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -1,0 +1,32 @@
+use serde_json::Value;
+
+const WARP_PLUGIN_KEY: &str = "warp@claude-code-warp";
+
+/// Whether the warp/claude-code-warp Claude Code plugin is currently
+/// installed in the user's `~/.claude` config.
+///
+/// We read `~/.claude/plugins/installed_plugins.json` and check for a
+/// `plugins["warp@claude-code-warp"]` entry with at least one item. The
+/// schema (version 2 at the time of writing) maps each
+/// `<plugin>@<marketplace>` key to an array of install records. Any
+/// failure (missing file, bad JSON, schema drift) returns `false` —
+/// "we couldn't confirm" is treated as "not installed" so the UI errs
+/// on the side of guiding the user to install.
+#[tauri::command]
+pub fn is_warp_plugin_installed() -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let path = home.join(".claude/plugins/installed_plugins.json");
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&raw) else {
+        return false;
+    };
+    json.get("plugins")
+        .and_then(|p| p.get(WARP_PLUGIN_KEY))
+        .and_then(|v| v.as_array())
+        .map(|arr| !arr.is_empty())
+        .unwrap_or(false)
+}

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -213,7 +213,7 @@ function SettingsView(props: { onBack: () => void }) {
       <div class="overflow-y-auto flex-1 py-1">
         <ToggleRow
           label="Task complete"
-          help="Notify when Claude finishes a turn."
+          help="Notify after every assistant reply (fires often during long agentic loops)."
           checked={notifications.prefs().notifySessionComplete}
           onToggle={() => toggle("notifySessionComplete")}
         />

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,14 +1,18 @@
 import {
   For,
   Show,
+  createEffect,
   createMemo,
   createSignal,
   onCleanup,
   onMount,
 } from "solid-js";
-import { Bell, BellOff } from "lucide-solid";
+import { ArrowLeft, Bell, BellOff, Settings } from "lucide-solid";
 import { useNotifications, type UnreadItem } from "@/context/notifications";
+import type { NotificationPrefs } from "@/lib/notifications-prefs";
 import { relativeTime } from "@/lib/relative-time";
+
+type View = "list" | "settings";
 
 function projectName(projectPath: string): string {
   const trimmed = projectPath.replace(/\/+$/, "");
@@ -19,10 +23,16 @@ function projectName(projectPath: string): string {
 export function NotificationBell() {
   const notifications = useNotifications();
   const [open, setOpen] = createSignal(false);
+  const [view, setView] = createSignal<View>("list");
   let wrapRef: HTMLDivElement | undefined;
 
   const items = createMemo(() => notifications.unreadItems());
   const count = createMemo(() => items().length);
+
+  // Every reopen lands on the list — settings is opt-in per session.
+  createEffect(() => {
+    if (open()) setView("list");
+  });
 
   onMount(() => {
     const onDown = (e: PointerEvent) => {
@@ -67,41 +77,79 @@ export function NotificationBell() {
 
       <Show when={open()}>
         <div class="absolute right-0 top-full mt-1 z-50 w-[360px] max-h-[480px] rounded-md border border-neutral-800 bg-neutral-900 shadow-xl text-[12px] flex flex-col">
-          <div class="px-3 py-2 border-b border-neutral-800 flex items-center justify-between">
-            <span class="text-[10px] uppercase tracking-wide text-neutral-500 font-medium">
-              Notifications
-            </span>
-            <Show when={count() > 0}>
-              <button
-                type="button"
-                class="text-[11px] text-neutral-400 hover:text-neutral-100 transition"
-                onClick={() => notifications.clearAllItems()}
-              >
-                Mark all read
-              </button>
-            </Show>
-          </div>
-
           <Show
-            when={count() > 0}
+            when={view() === "settings"}
             fallback={
-              <div class="px-3 py-8 flex flex-col items-center gap-2 text-neutral-500">
-                <BellOff size={20} strokeWidth={1.5} />
-                <span class="text-[12px]">No notifications</span>
-              </div>
+              <ListView
+                items={items()}
+                count={count()}
+                onItemClick={handleItemClick}
+                onMarkAllRead={() => notifications.clearAllItems()}
+                onOpenSettings={() => setView("settings")}
+              />
             }
           >
-            <div class="overflow-y-auto flex-1 py-1">
-              <For each={items()}>
-                {(item) => (
-                  <BellItem item={item} onClick={() => handleItemClick(item)} />
-                )}
-              </For>
-            </div>
+            <SettingsView onBack={() => setView("list")} />
           </Show>
         </div>
       </Show>
     </div>
+  );
+}
+
+function ListView(props: {
+  items: readonly UnreadItem[];
+  count: number;
+  onItemClick: (item: UnreadItem) => void;
+  onMarkAllRead: () => void;
+  onOpenSettings: () => void;
+}) {
+  return (
+    <>
+      <div class="px-3 py-2 border-b border-neutral-800 flex items-center justify-between gap-2">
+        <span class="text-[10px] uppercase tracking-wide text-neutral-500 font-medium">
+          Notifications
+        </span>
+        <div class="flex items-center gap-1">
+          <Show when={props.count > 0}>
+            <button
+              type="button"
+              class="text-[11px] text-neutral-400 hover:text-neutral-100 transition px-1"
+              onClick={props.onMarkAllRead}
+            >
+              Mark all read
+            </button>
+          </Show>
+          <button
+            type="button"
+            class="w-6 h-6 rounded flex items-center justify-center text-neutral-500 hover:text-neutral-100 hover:bg-neutral-800/80 transition"
+            onClick={props.onOpenSettings}
+            aria-label="Notification settings"
+            title="Notification settings"
+          >
+            <Settings size={13} strokeWidth={1.75} />
+          </button>
+        </div>
+      </div>
+
+      <Show
+        when={props.count > 0}
+        fallback={
+          <div class="px-3 py-8 flex flex-col items-center gap-2 text-neutral-500">
+            <BellOff size={20} strokeWidth={1.5} />
+            <span class="text-[12px]">No notifications</span>
+          </div>
+        }
+      >
+        <div class="overflow-y-auto flex-1 py-1">
+          <For each={props.items}>
+            {(item) => (
+              <BellItem item={item} onClick={() => props.onItemClick(item)} />
+            )}
+          </For>
+        </div>
+      </Show>
+    </>
   );
 }
 
@@ -136,5 +184,88 @@ function BellItem(props: { item: UnreadItem; onClick: () => void }) {
         </span>
       </span>
     </button>
+  );
+}
+
+function SettingsView(props: { onBack: () => void }) {
+  const notifications = useNotifications();
+
+  function toggle(key: keyof NotificationPrefs) {
+    notifications.updatePrefs({ [key]: !notifications.prefs()[key] });
+  }
+
+  return (
+    <>
+      <div class="px-2 py-2 border-b border-neutral-800 flex items-center gap-1">
+        <button
+          type="button"
+          class="w-6 h-6 rounded flex items-center justify-center text-neutral-400 hover:text-neutral-100 hover:bg-neutral-800/80 transition"
+          onClick={props.onBack}
+          aria-label="Back to notifications"
+          title="Back"
+        >
+          <ArrowLeft size={13} strokeWidth={1.75} />
+        </button>
+        <span class="text-[10px] uppercase tracking-wide text-neutral-500 font-medium">
+          Settings
+        </span>
+      </div>
+      <div class="overflow-y-auto flex-1 py-1">
+        <ToggleRow
+          label="Task complete"
+          help="Notify when Claude finishes a turn."
+          checked={notifications.prefs().notifySessionComplete}
+          onToggle={() => toggle("notifySessionComplete")}
+        />
+        <ToggleRow
+          label="Permission requests"
+          help="Notify when Claude needs permission. Requires the warp/claude-code-warp plugin."
+          checked={notifications.prefs().notifyPermission}
+          onToggle={() => toggle("notifyPermission")}
+        />
+        <ToggleRow
+          label="Sounds"
+          help="Play a chime with each notification."
+          checked={notifications.prefs().playSounds}
+          onToggle={() => toggle("playSounds")}
+        />
+      </div>
+    </>
+  );
+}
+
+function ToggleRow(props: {
+  label: string;
+  help: string;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div class="px-3 py-2 flex items-start justify-between gap-3">
+      <div class="flex-1 min-w-0">
+        <div class="text-[12px] text-neutral-100 font-medium">{props.label}</div>
+        <div class="text-[11px] text-neutral-400 mt-0.5">{props.help}</div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.checked}
+        aria-label={props.label}
+        onClick={props.onToggle}
+        class="shrink-0 mt-0.5 w-9 h-5 rounded-full transition relative"
+        classList={{
+          "bg-emerald-500/80": props.checked,
+          "bg-neutral-700": !props.checked,
+        }}
+      >
+        <span
+          class="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-all"
+          classList={{
+            "left-[18px]": props.checked,
+            "left-0.5": !props.checked,
+          }}
+        />
+      </button>
+    </div>
   );
 }

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -6,11 +6,16 @@ import {
   createSignal,
   onCleanup,
   onMount,
+  type JSX,
 } from "solid-js";
 import { ArrowLeft, Bell, BellOff, Settings } from "lucide-solid";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useNotifications, type UnreadItem } from "@/context/notifications";
 import type { NotificationPrefs } from "@/lib/notifications-prefs";
 import { relativeTime } from "@/lib/relative-time";
+
+const WARP_PLUGIN_INSTALL_URL =
+  "https://github.com/willywg/klaudio-panels#permission-requests-recommended-warp-plugin";
 
 type View = "list" | "settings";
 
@@ -190,9 +195,41 @@ function BellItem(props: { item: UnreadItem; onClick: () => void }) {
 function SettingsView(props: { onBack: () => void }) {
   const notifications = useNotifications();
 
+  // Re-check on mount of the settings view so users who installed the
+  // warp plugin without restarting Klaudio see the row enable itself
+  // when they reopen ⚙️.
+  onMount(() => {
+    void notifications.refreshWarpInstalled();
+  });
+
   function toggle(key: keyof NotificationPrefs) {
     notifications.updatePrefs({ [key]: !notifications.prefs()[key] });
   }
+
+  function openInstallDocs() {
+    void openUrl(WARP_PLUGIN_INSTALL_URL).catch(() => {});
+  }
+
+  // Permission row is gated on the plugin: without it, no events ever
+  // arrive and an enabled toggle would lie to the user. Render disabled
+  // + visually-off, with a link to the install docs in the helper text.
+  const permissionEnabled = () => notifications.warpInstalled();
+
+  const permissionHelp = (): JSX.Element =>
+    permissionEnabled() ? (
+      <>Notify when Claude needs permission to use a tool (Bash, Edit, …).</>
+    ) : (
+      <>
+        Requires the warp/claude-code-warp plugin.{" "}
+        <button
+          type="button"
+          class="text-indigo-400 hover:text-indigo-300 underline underline-offset-2 transition"
+          onClick={openInstallDocs}
+        >
+          Install →
+        </button>
+      </>
+    );
 
   return (
     <>
@@ -219,9 +256,12 @@ function SettingsView(props: { onBack: () => void }) {
         />
         <ToggleRow
           label="Permission requests"
-          help="Notify when Claude needs permission. Requires the warp/claude-code-warp plugin."
-          checked={notifications.prefs().notifyPermission}
+          help={permissionHelp()}
+          checked={
+            permissionEnabled() && notifications.prefs().notifyPermission
+          }
           onToggle={() => toggle("notifyPermission")}
+          disabled={!permissionEnabled()}
         />
         <ToggleRow
           label="Sounds"
@@ -236,12 +276,16 @@ function SettingsView(props: { onBack: () => void }) {
 
 function ToggleRow(props: {
   label: string;
-  help: string;
+  help: JSX.Element;
   checked: boolean;
   onToggle: () => void;
+  disabled?: boolean;
 }) {
   return (
-    <div class="px-3 py-2 flex items-start justify-between gap-3">
+    <div
+      class="px-3 py-2 flex items-start justify-between gap-3"
+      classList={{ "opacity-60": props.disabled }}
+    >
       <div class="flex-1 min-w-0">
         <div class="text-[12px] text-neutral-100 font-medium">{props.label}</div>
         <div class="text-[11px] text-neutral-400 mt-0.5">{props.help}</div>
@@ -250,12 +294,18 @@ function ToggleRow(props: {
         type="button"
         role="switch"
         aria-checked={props.checked}
+        aria-disabled={props.disabled || undefined}
         aria-label={props.label}
-        onClick={props.onToggle}
+        onClick={() => {
+          if (props.disabled) return;
+          props.onToggle();
+        }}
+        disabled={props.disabled}
         class="shrink-0 mt-0.5 w-9 h-5 rounded-full transition relative"
         classList={{
-          "bg-emerald-500/80": props.checked,
-          "bg-neutral-700": !props.checked,
+          "bg-emerald-500/80": props.checked && !props.disabled,
+          "bg-neutral-700": !props.checked || props.disabled,
+          "cursor-not-allowed": props.disabled,
         }}
       >
         <span

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -11,6 +11,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { playPermissionRequest, playTaskComplete } from "@/lib/sound";
+import {
+  getPrefs,
+  setPrefs,
+  type NotificationPrefs,
+} from "@/lib/notifications-prefs";
 
 type SessionCompletePayload = {
   project_path: string;
@@ -119,6 +124,16 @@ function makeNotificationsContext() {
   // (a Klaudio restart starts the bell empty by design).
   const [unreadItems, setUnreadItems] = createSignal<readonly UnreadItem[]>([]);
   let nextItemId = 1;
+
+  // Per-channel kill switches surfaced from the bell ⚙️ panel. Read at
+  // every event entry point — disabling a channel produces zero side
+  // effects (no ring, no bell, no toast, no banner, no chime).
+  const [prefs, setPrefsSignal] = createSignal<NotificationPrefs>(getPrefs());
+
+  function updatePrefs(patch: Partial<NotificationPrefs>) {
+    setPrefs(patch);
+    setPrefsSignal(getPrefs());
+  }
 
   // Default no-op resolver until App.tsx wires the real one.
   let resolver: ProjectResolver = {
@@ -316,7 +331,8 @@ function makeNotificationsContext() {
   }
 
   function handleComplete(payload: SessionCompletePayload) {
-    playTaskComplete();
+    if (!prefs().notifySessionComplete) return;
+    if (prefs().playSounds) playTaskComplete();
     const title = `${projectName(payload.project_path)} · Claude is done`;
     const body =
       payload.preview && payload.preview.length > 0
@@ -329,10 +345,11 @@ function makeNotificationsContext() {
     // Only `permission_request` reaches the frontend — `stop` and
     // `idle_prompt` are dropped server-side in cli_agent.rs.
     if (payload.event !== "permission_request") return;
+    if (!prefs().notifyPermission) return;
     const projectPath = resolver.resolveOpenProject(payload.cwd);
     if (!projectPath) return;
 
-    playPermissionRequest();
+    if (prefs().playSounds) playPermissionRequest();
     const tool = payload.tool_name ?? "a tool";
     const preview = payload.tool_input_preview;
     const body = preview && preview.length > 0 ? `${tool}: ${preview}` : tool;
@@ -353,6 +370,8 @@ function makeNotificationsContext() {
     unreadItems,
     activateProjectFromBell,
     clearAllItems,
+    prefs,
+    updatePrefs,
   };
 }
 

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -135,6 +135,22 @@ function makeNotificationsContext() {
     setPrefsSignal(getPrefs());
   }
 
+  // Warp plugin install state. The Permission row in settings is gated
+  // on this — without the plugin no `permission_request` events fire,
+  // so showing an enabled toggle would be misleading. Seeded async on
+  // mount; refresh-on-demand from the settings view covers users who
+  // install the plugin without restarting Klaudio.
+  const [warpInstalled, setWarpInstalled] = createSignal<boolean>(false);
+
+  async function refreshWarpInstalled() {
+    try {
+      const v = await invoke<boolean>("is_warp_plugin_installed");
+      setWarpInstalled(v);
+    } catch {
+      setWarpInstalled(false);
+    }
+  }
+
   // Default no-op resolver until App.tsx wires the real one.
   let resolver: ProjectResolver = {
     isActiveProject: () => false,
@@ -294,6 +310,8 @@ function makeNotificationsContext() {
     unlistenAgent = await listen<CliAgentEvent>("claude:event", (e) =>
       handleAgentEvent(e.payload),
     );
+
+    void refreshWarpInstalled();
   });
 
   onCleanup(() => {
@@ -372,6 +390,8 @@ function makeNotificationsContext() {
     clearAllItems,
     prefs,
     updatePrefs,
+    warpInstalled,
+    refreshWarpInstalled,
   };
 }
 

--- a/src/lib/notifications-prefs.ts
+++ b/src/lib/notifications-prefs.ts
@@ -1,0 +1,38 @@
+export type NotificationPrefs = {
+  notifySessionComplete: boolean;
+  notifyPermission: boolean;
+  playSounds: boolean;
+};
+
+const KEY = "notificationPrefs";
+
+const DEFAULTS: NotificationPrefs = {
+  notifySessionComplete: true,
+  notifyPermission: true,
+  playSounds: true,
+};
+
+export function getPrefs(): NotificationPrefs {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<NotificationPrefs>;
+    return {
+      notifySessionComplete:
+        parsed.notifySessionComplete ?? DEFAULTS.notifySessionComplete,
+      notifyPermission: parsed.notifyPermission ?? DEFAULTS.notifyPermission,
+      playSounds: parsed.playSounds ?? DEFAULTS.playSounds,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export function setPrefs(patch: Partial<NotificationPrefs>): void {
+  try {
+    const next = { ...getPrefs(), ...patch };
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    // best-effort: storage may be denied in some webview configs.
+  }
+}


### PR DESCRIPTION
## Summary

- Adds three localStorage-backed toggles (`notifySessionComplete`, `notifyPermission`, `playSounds`) honored at the entry point in `notifications.tsx`.
- Surfaces them inline from the bell popover via a ⚙️ Settings panel (back-arrow returns to the list view; popover always opens on the list).
- Bumps the warp plugin recommendation to the top of the README's Notifications section since `permission_request` is the higher-signal channel.
- PRP: [PRPs/015--notification-preferences.md](./PRPs/015--notification-preferences.md)

Fixes #36.

## Open question for review

I shipped with **all toggles defaulting to ON** to preserve v1.6.0 behavior — no UX regression, and the new ⚙️ panel is the opt-out.

The bug report leans the other way ("users without the plugin shouldn't suffer this"), so an equally defensible default is `notifySessionComplete: false` — fix the spam for everyone immediately, opt-in for people who want it back. One-line change in `src/lib/notifications-prefs.ts:DEFAULTS` if you want me to flip it.

## Manual testing — NOT done in this PR

CLAUDE.md asks for manual UI verification before reporting UI work as done. I ran `bun run typecheck` (✓) and `cd src-tauri && cargo check` (✓), but did not start the dev server to click through the popover. Suggested manual checks before merge:

- [ ] Bell → ⚙️ opens settings; ← returns to list.
- [ ] Each toggle persists across a Klaudio restart (close + reopen the app).
- [ ] With **Task complete** off: trigger a Claude end_turn — no toast, no bell entry, no banner, no chime, no amber ring.
- [ ] With **Permission requests** off (warp plugin installed): trigger a `permission_request` (e.g. `Bash(ls /tmp)`) — no toast, no bell entry, no banner, no chime, no amber ring.
- [ ] With **Sounds** off only: toasts/banners/bell still appear; no chimes.
- [ ] All-off keeps the app silent regardless of plugin state.
- [ ] Outside-click and Escape close the popover from either mode.

## Test plan
- [ ] `bun run typecheck` (passing)
- [ ] `cd src-tauri && cargo check` (passing)
- [ ] Manual UI checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)