### PR TITLE
fix(terminal): stop shell + editor from stealing focus on project re-entry (#40)

### DIFF
--- a/PRPs/017--fix-focus-steal-on-project-switch.md
+++ b/PRPs/017--fix-focus-steal-on-project-switch.md
@@ -1,7 +1,8 @@
 # PRP 017: Stop secondary terminals from stealing focus on project re-entry
 
-> **Version:** 1.0
+> **Version:** 1.1
 > **Created:** 2026-05-08
+> **Updated:** 2026-05-11 — added focus-bus for user-action tab activation
 > **Status:** Draft
 > **Tracks:** [#40](https://github.com/willywg/klaudio-panels/issues/40)
 
@@ -103,6 +104,61 @@ If QA shows the click-tab-strip path feels broken, the follow-up
 is to add `term.focus()` to the tab-strip `onActivate` handler in
 the panel components (not back into the activation effect, which
 fires on project re-entry too and resurrects the race).
+
+## v1.1 addendum — focus-bus for user actions
+
+The base PR shipped the "remove activation focus from shell + editor"
+half. In practice that left a real regression: clicking "+" or a tab
+header on the shell/editor strip no longer focused the xterm — which
+is the exact UX the user *does* want, because those clicks are
+explicit "I want to type here" gestures.
+
+**Rule we're now encoding**: user-action tab activation focuses the
+target; passive activation (project switch, auto-resume, auto-spawn)
+does not.
+
+A new module `src/lib/terminal-focus-bus.ts` mirrors the existing
+`terminal-scroll-bus`: every xterm-hosting view registers a focus
+callback keyed by its PTY id on mount, and unregisters on cleanup.
+User-action handlers call `focusTerminal(id)`; passive code paths
+never call it. Newly-created tabs (where the view hasn't mounted by
+the time the handler fires) are queued for ≤500ms and focused as
+soon as registration happens.
+
+Call sites added:
+
+| Handler | File | Action |
+| --- | --- | --- |
+| Shell "+" | `shell-terminal-panel.tsx:handleNewTab` | `focusTerminal(newPtyId)` after `openTab` resolves |
+| Shell tab click | `shell-terminal-panel.tsx:handleActivate` | `focusTerminal(ptyId)` after `setActiveForProject` |
+| Editor "Open in" (new) | `diff-panel.tsx:dispatchAppOpen` | `focusTerminal(ptyId)` after `openEditor + addEditorTab` |
+| Editor "Open in" (existing) | `diff-panel.tsx:dispatchAppOpen` | `focusTerminal(existingTab.ptyId)` for already-open editor PTY |
+| Editor tab click | `diff-panel.tsx:onActivate` | `focusTerminal(tab.ptyId)` if `tab.kind === "editor"` |
+
+Views that register: `shell-terminal-view.tsx`, `editor-pty-view.tsx`.
+Claude's `terminal-view.tsx` is **not** in the bus — its existing
+activation-effect focus already covers both project-re-entry and
+user-action focus for Claude tabs, and adding the bus would
+double-focus harmlessly but for no reason. If a future change
+removes Claude's activation focus, this is where to wire it in.
+
+**What still doesn't focus on purpose**:
+
+- Project switch back into a project (App.tsx:202-221).
+- Auto-resume of last session on project open.
+- Shell-panel auto-spawn of the first tab when the panel opens
+  (shell-terminal-panel.tsx:37-47) — the user opened the panel, but
+  if focus jumped immediately we'd race with whatever they were
+  doing before clicking the panel toggle.
+
+QA additions (on top of the original checklist):
+
+- New shell tab "+": focuses immediately, can type without clicking.
+- Shell tab strip header click: focuses the target shell.
+- "Open in <editor>" on a file: focuses the editor PTY.
+- Editor tab strip click between two editor PTYs: focuses target.
+- Editor tab strip click on a file-preview tab: doesn't crash and
+  doesn't steal focus (no-op — file preview is not a terminal).
 
 ## QA checklist
 

--- a/PRPs/017--fix-focus-steal-on-project-switch.md
+++ b/PRPs/017--fix-focus-steal-on-project-switch.md
@@ -1,8 +1,9 @@
 # PRP 017: Stop secondary terminals from stealing focus on project re-entry
 
-> **Version:** 1.1
+> **Version:** 1.2
 > **Created:** 2026-05-08
-> **Updated:** 2026-05-11 — added focus-bus for user-action tab activation
+> **Updated:** 2026-05-11 — focus-bus + per-project memory; remove Claude's
+> activation-effect focus for full consistency
 > **Status:** Draft
 > **Tracks:** [#40](https://github.com/willywg/klaudio-panels/issues/40)
 
@@ -142,14 +143,80 @@ user-action focus for Claude tabs, and adding the bus would
 double-focus harmlessly but for no reason. If a future change
 removes Claude's activation focus, this is where to wire it in.
 
+## v1.2 addendum — per-project memory + Claude joins the bus
+
+v1.1 left the inverse of the original bug in place: if the user was
+last typing in the shell in Project A and switched away and back,
+Claude's activation effect would still call `term.focus()` on
+re-entry and steal the cursor from where the user actually was. The
+rule "passive activation never focuses" was right; Claude's
+activation effect was the last violator.
+
+**v1.2 changes**:
+
+1. Remove `term.focus()` from Claude's activation effect
+   (`terminal-view.tsx:297-312`). Now every view's activation effect
+   only does refresh + delayed fit; none of them call focus.
+2. Claude joins the focus-bus. `terminal-view.tsx` registers in
+   `onMount` and unregisters in `onCleanup`, same shape as shell /
+   editor.
+3. All three views (Claude, shell, editor) attach a `focus` listener
+   on `term.textarea` that calls `recordTerminalFocus(ptyId)`. This
+   catches direct clicks on the xterm body (which focus the hidden
+   textarea natively), keeping `lastFocusedForProject` accurate even
+   when the bus's explicit `focusTerminal` isn't invoked.
+4. The focus-bus gains per-project memory:
+   - `registerTerminalFocus(id, projectPath, fn)` — registration now
+     takes `projectPath` so the bus can attribute focus to a project.
+   - `recordTerminalFocus(id)` — update the per-project memory
+     without calling focus (used by the textarea focus listener).
+   - `lastFocusedForProject(projectPath)` — read accessor.
+   - `unregisterTerminalFocus(id)` clears the per-project record if
+     the disappearing PTY held it.
+5. `App.tsx`'s project-switch effect now does, after picking
+   `nextActive` and calling `term.setActiveTab(nextActive)`:
+   ```
+   const target = lastFocusedForProject(p) ?? nextActive;
+   requestAnimationFrame(() => focusTerminal(target));
+   ```
+   `requestAnimationFrame` is required because focusing a textarea
+   inside `visibility: hidden` doesn't stick in WebKit; we need to
+   wait one frame for Solid's reactive visibility flip to land.
+6. `App.tsx` user-action Claude paths now also call `focusTerminal`:
+   - `openNewTab` after `term.openTab` resolves.
+   - `openResumeTab` (used by sidebar session-click).
+   - `handleSelectSession` when an existing tab is reused.
+   - `handleActivateTab` (tab-strip click).
+   - `maybeAutoResume` after the auto-resumed tab opens.
+
+Net effect: focus is **never** a side effect of a visibility flip.
+It is always triggered by either an explicit user action or the
+per-project memory restoration in the project-switch effect. Both
+sides of #40 (shell stealing from Claude, Claude stealing from
+shell) are closed by the same uniform rule.
+
+**Call-site matrix after v1.2**:
+
+| Trigger | Where focus call lives |
+| --- | --- |
+| Project switch in | `App.tsx` project-switch effect (rAF) |
+| Claude "+" | `App.tsx:openNewTab` |
+| Claude session-click | `App.tsx:handleSelectSession` / `openResumeTab` |
+| Claude tab click | `App.tsx:handleActivateTab` |
+| Claude auto-resume | `App.tsx:maybeAutoResume` (after `openTab`) |
+| Shell "+" | `shell-terminal-panel.tsx:handleNewTab` |
+| Shell tab click | `shell-terminal-panel.tsx:handleActivate` |
+| Editor open-in (new + existing) | `diff-panel.tsx:dispatchAppOpen` |
+| Editor tab click | `diff-panel.tsx:onActivate` |
+| Direct xterm body click | `term.textarea` focus listener → `recordTerminalFocus` (memory only) |
+
 **What still doesn't focus on purpose**:
 
-- Project switch back into a project (App.tsx:202-221).
-- Auto-resume of last session on project open.
 - Shell-panel auto-spawn of the first tab when the panel opens
-  (shell-terminal-panel.tsx:37-47) — the user opened the panel, but
-  if focus jumped immediately we'd race with whatever they were
-  doing before clicking the panel toggle.
+  (shell-terminal-panel.tsx:37-47). The user opened the panel; if
+  focus jumped immediately we'd race with whatever they were doing
+  before clicking the panel toggle.
+- No project active (sidebar empty / home screen).
 
 QA additions (on top of the original checklist):
 
@@ -159,6 +226,13 @@ QA additions (on top of the original checklist):
 - Editor tab strip click between two editor PTYs: focuses target.
 - Editor tab strip click on a file-preview tab: doesn't crash and
   doesn't steal focus (no-op — file preview is not a terminal).
+- **Inverse of #40**: Project A with Claude + shell open, last
+  interaction was in shell. Switch to B, switch back to A. Cursor
+  must land in the shell, not in Claude.
+- **First entry of a project** (this session): focus lands on the
+  active Claude tab.
+- **Close a shell tab, switch project, switch back**: Claude focuses
+  (memory cleared on unregister, falls back to active Claude tab).
 
 ## QA checklist
 

--- a/PRPs/017--fix-focus-steal-on-project-switch.md
+++ b/PRPs/017--fix-focus-steal-on-project-switch.md
@@ -1,0 +1,145 @@
+# PRP 017: Stop secondary terminals from stealing focus on project re-entry
+
+> **Version:** 1.0
+> **Created:** 2026-05-08
+> **Status:** Draft
+> **Tracks:** [#40](https://github.com/willywg/klaudio-panels/issues/40)
+
+---
+
+## Goal
+
+After switching away from a project and back, the keyboard cursor
+must land on the Claude tab the user was last using, not on the
+shell terminal or the editor PTY. Today the secondary surfaces
+(shell, editor) win a focus race and silently capture keystrokes —
+which has, on at least one occasion, caused accidental input into
+a running `npm run dev`.
+
+## Why
+
+Three terminal surfaces all install the same activation effect:
+
+| File | Line | What it does |
+| --- | --- | --- |
+| `src/components/terminal-view.tsx` | 297-312 | Claude tab. Synchronous `term?.focus()` at line 302. |
+| `src/components/shell-terminal/shell-terminal-view.tsx` | 223-235 | Shell tab. `term?.focus()` at line 230, wrapped in `requestAnimationFrame()`. |
+| `src/components/diff-panel/editor-pty-view.tsx` | 261-273 | Editor PTY tab. Synchronous `term?.focus()` at line 268. |
+
+Tabs are mounted-once and visibility-toggled (CLAUDE.md §9), so on
+project re-entry **every selected tab in every panel** flips
+`props.active=true` simultaneously. Each `createEffect` fires, each
+calls `term.focus()`, and whichever runs last owns
+`document.activeElement` — typically the shell, because its rAF
+defers it past Claude's synchronous call.
+
+There is no coordination between the panels. They are independent
+trees rendered side-by-side, so an "ordering" fix would require
+inventing cross-tree state. The simpler fix is to admit there is
+exactly one **primary** surface (Claude) and let the secondaries
+never auto-focus.
+
+## What changes
+
+**Drop the `term?.focus()` line from shell-terminal-view and
+editor-pty-view activation effects. Keep refresh + delayed fit.**
+
+Claude's activation effect is unchanged — it still focuses, so the
+new-Claude-tab and within-project tab-switch UX remains intact.
+
+```diff
+ // src/components/shell-terminal/shell-terminal-view.tsx
+ createEffect(() => {
+   if (!props.active) return;
+   requestAnimationFrame(() => {
+     if (disposed) return;
+     safeFit();
+     try {
+       if (term) term.refresh(0, term.rows - 1);
+-      term?.focus();
+     } catch {
+       // ignore
+     }
+   });
+ });
+```
+
+```diff
+ // src/components/diff-panel/editor-pty-view.tsx
+ createEffect(() => {
+   if (!props.active) return;
+   ...
+   safeFit("active-change");
+   try {
+     if (term) term.refresh(0, term.rows - 1);
+-    term?.focus();
+   } catch {
+     // ignore
+   }
+   ...
+ });
+```
+
+That is the entire diff. No new state, no new props, no lifecycle
+changes.
+
+## Trade-offs
+
+- **Regression**: clicking the shell or editor tab strip header
+  (not the xterm body) no longer auto-focuses the xterm. The user
+  must click inside the terminal area before typing. xterm.js's
+  built-in canvas-click handler still focuses on direct clicks, so
+  the cost is one extra click only when the user activated the tab
+  via the strip header. We accept this in exchange for never
+  stealing focus from Claude.
+- **First-time shell-panel open**: same caveat — the shell xterm
+  does not auto-focus when the panel first appears. Again, one
+  click resolves it.
+- **Editor PTY**: same caveat. The editor PTY is launched inside
+  the diff panel; users typically click the editor itself, which
+  xterm handles natively.
+
+If QA shows the click-tab-strip path feels broken, the follow-up
+is to add `term.focus()` to the tab-strip `onActivate` handler in
+the panel components (not back into the activation effect, which
+fires on project re-entry too and resurrects the race).
+
+## QA checklist
+
+Manual, in `bun tauri dev`:
+
+1. **Reproduce #40 first**: project A with Claude + Shell tabs,
+   project B with Claude only. Type into Claude A, switch to B,
+   type into Claude B, switch back to A. Confirm cursor is in
+   Claude A and the next keystroke goes there. Pre-fix this
+   should fail; post-fix it should pass.
+2. **New session focus**: from home screen, open a project and
+   click "+ New session". Cursor should land in the new Claude
+   xterm without a click. (terminal-view.tsx is unchanged so this
+   should still work.)
+3. **Within-project tab switch**: in a project with two Claude
+   tabs, click one then the other from the tab strip. Each click
+   should focus the freshly-selected tab. (Unchanged Claude path.)
+4. **Shell panel first open**: open a project, hit the shell
+   keyboard shortcut / button, click into the shell xterm body —
+   typing works. Acceptable: clicking the shell *tab strip header*
+   doesn't auto-focus.
+5. **Editor PTY in diff panel**: open a file diff, the PTY editor
+   appears. Click into it, typing works. Acceptable: it does not
+   auto-focus on appearance.
+6. **No regression of #38**: rapid project switching does not
+   bring back the welcome banner or upward scroll drift.
+
+## Out of scope
+
+- Reworking the multi-panel focus model.
+- Restoring "last focused element per project" — the browser does
+  not support this natively and emulating it adds state we don't
+  need.
+- Touching the diff panel's auto-show/hide logic (#7, #38).
+
+## Risk
+
+Low. The change is one deletion per file in two files; everything
+else (xterm lifecycle, fit, refresh, scrollback, WebGL) is
+untouched.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,10 @@ import {
 } from "@/lib/panel-layout";
 import { ShellTerminalPanel } from "@/components/shell-terminal/shell-terminal-panel";
 import { requestScrollToBottom } from "@/lib/terminal-scroll-bus";
+import {
+  focusTerminal,
+  lastFocusedForProject,
+} from "@/lib/terminal-focus-bus";
 import { displayLabel } from "@/lib/session-label";
 
 const AUTO_RESUME_FAIL_WINDOW_MS = 2000;
@@ -199,6 +203,14 @@ function Shell() {
   // On active project change, pick the right tab to show (remembered > first
   // existing > null). If none, consider auto-resume. This is the SOLE place
   // that calls term.setActiveTab as a response to project switch.
+  //
+  // After picking the active Claude tab, restore keyboard focus to whichever
+  // terminal in THIS project had it last (Claude / shell / editor PTY). If
+  // no record exists (first entry), fall back to the active Claude tab.
+  // Deferred to rAF so the visibility flip — driven by reactive `props.active`
+  // becoming true — has happened before we call term.focus(); focusing an
+  // element inside `visibility: hidden` doesn't stick in WebKit. See PRP 017
+  // v1.2 / #40.
   createEffect(
     on(activeProjectPath, (p) => {
       if (!p) {
@@ -216,7 +228,17 @@ function Shell() {
         nextActive = tabsInProject[0].id;
       }
       term.setActiveTab(nextActive);
-      if (nextActive === null) maybeAutoResume(p);
+      if (nextActive === null) {
+        maybeAutoResume(p);
+        return;
+      }
+      const target = lastFocusedForProject(p) ?? nextActive;
+      requestAnimationFrame(() => {
+        // If the user has already switched away from `p` during the
+        // ~16ms rAF window, don't focus a now-hidden xterm.
+        if (activeProjectPath() !== p) return;
+        focusTerminal(target);
+      });
     }),
   );
 
@@ -543,7 +565,11 @@ function Shell() {
     const p = activeProjectPath();
     if (!p) return;
     try {
-      await term.openTab(p, [], { label: "New session", sessionId: null });
+      const id = await term.openTab(p, [], {
+        label: "New session",
+        sessionId: null,
+      });
+      focusTerminal(id);
     } catch (err) {
       console.error("openTab(new) failed", err);
     } finally {
@@ -557,10 +583,11 @@ function Shell() {
     label: string,
   ) {
     try {
-      await term.openTab(projectPath, ["--resume", sessionId], {
+      const id = await term.openTab(projectPath, ["--resume", sessionId], {
         label,
         sessionId,
       });
+      focusTerminal(id);
     } catch (err) {
       console.error("openTab(resume) failed", err);
     } finally {
@@ -576,6 +603,7 @@ function Shell() {
     );
     if (existing) {
       term.setActiveTab(existing.id);
+      focusTerminal(existing.id);
       return;
     }
     void openResumeTab(p, meta.id, displayLabel(meta));
@@ -583,6 +611,7 @@ function Shell() {
 
   function handleActivateTab(id: string) {
     term.setActiveTab(id);
+    focusTerminal(id);
   }
 
   async function handleCloseTab(id: string) {
@@ -627,6 +656,11 @@ function Shell() {
           ["--resume", lastId],
           { label, sessionId: lastId },
         );
+        // The project-switch effect ran before tabs existed for this project
+        // and skipped its focus call. Now that auto-resume materialised a
+        // tab, hand the cursor to it — the user just opened the project to
+        // use Claude.
+        focusTerminal(tabId);
         const detach = term.onExit(tabId, (code) => {
           const elapsed = Date.now() - spawnedAt;
           if (elapsed < AUTO_RESUME_FAIL_WINDOW_MS && code !== 0) {

--- a/src/components/diff-panel/diff-panel.tsx
+++ b/src/components/diff-panel/diff-panel.tsx
@@ -18,6 +18,7 @@ import { useOpenIn } from "@/context/open-in";
 import { useEditorPty } from "@/context/editor-pty";
 import { ContextMenu, type ContextMenuItem } from "@/components/context-menu";
 import { createInternalDrag } from "@/lib/use-internal-drag";
+import { focusTerminal } from "@/lib/terminal-focus-bus";
 import { DiffFileRow } from "./diff-file-row";
 import { FilePreview } from "./file-preview";
 import { EditorPtyView } from "./editor-pty-view";
@@ -260,6 +261,12 @@ function TabStrip(props: { projectPath: string }) {
       if (existing) {
         panel.setActiveTab(props.projectPath, existing);
         panel.openPanel(props.projectPath);
+        const existingTab = panel
+          .tabsFor(props.projectPath)
+          .find((t) => tabKey(t) === existing);
+        if (existingTab && existingTab.kind === "editor") {
+          focusTerminal(existingTab.ptyId);
+        }
         return;
       }
       try {
@@ -271,6 +278,10 @@ function TabStrip(props: { projectPath: string }) {
           editorId,
         );
         panel.addEditorTab(props.projectPath, editorId, rel, ptyId);
+        // User-action focus: explicit "Open in <editor>" — queue focus so
+        // the keystroke they make next lands in the editor PTY, not the
+        // file tree or wherever they triggered the menu from.
+        focusTerminal(ptyId);
       } catch (err) {
         console.warn("openEditor failed", err);
       }
@@ -358,7 +369,12 @@ function TabStrip(props: { projectPath: string }) {
                 tab={t}
                 projectPath={props.projectPath}
                 active={isActive()}
-                onActivate={() => panel.setActiveTab(props.projectPath, key)}
+                onActivate={() => {
+                  panel.setActiveTab(props.projectPath, key);
+                  // User-action focus only for editor PTY tabs; file
+                  // preview tabs aren't xterm-hosting surfaces.
+                  if (t.kind === "editor") focusTerminal(t.ptyId);
+                }}
                 onClose={() => panel.closeTab(props.projectPath, key)}
                 onContextMenu={(e) => {
                   if (t.kind === "file") {

--- a/src/components/diff-panel/editor-pty-view.tsx
+++ b/src/components/diff-panel/editor-pty-view.tsx
@@ -256,8 +256,12 @@ export function EditorPtyView(props: Props) {
     resizeObs.observe(container!);
   });
 
-  // WebGL canvas stops painting while `visibility: hidden` — same pattern as
-  // terminal-view.tsx: fit + refresh + focus on re-show.
+  // WebGL canvas stops painting while `visibility: hidden` — fit + refresh
+  // on re-show. Intentionally NOT calling term.focus() here for the same
+  // reason as shell-terminal-view: on project re-entry the editor PTY's
+  // active flag flips alongside Claude's, and a focus call here would race
+  // with Claude's. xterm's canvas click handler still focuses on direct
+  // clicks. See PRP 017 / #40.
   createEffect(() => {
     if (!props.active) return;
     requestAnimationFrame(() => {
@@ -265,7 +269,6 @@ export function EditorPtyView(props: Props) {
       safeFit("active-change");
       try {
         if (term) term.refresh(0, term.rows - 1);
-        term?.focus();
       } catch {
         // ignore
       }

--- a/src/components/diff-panel/editor-pty-view.tsx
+++ b/src/components/diff-panel/editor-pty-view.tsx
@@ -11,6 +11,7 @@ import {
 import { useEditorPty } from "@/context/editor-pty";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
 import {
+  recordTerminalFocus,
   registerTerminalFocus,
   unregisterTerminalFocus,
 } from "@/lib/terminal-focus-bus";
@@ -188,13 +189,25 @@ export function EditorPtyView(props: Props) {
     window.setTimeout(() => safeFit("onMount-220ms"), 220);
     window.setTimeout(() => safeFit("onMount-600ms"), 600);
 
-    registerTerminalFocus(props.ptyId, () => {
-      try {
-        term?.focus();
-      } catch {
-        // ignore
-      }
-    });
+    const projectPath = editorPty.getTab(props.ptyId)?.projectPath;
+    if (!projectPath) {
+      console.error(
+        `editor-pty-view: no projectPath for ${props.ptyId}; focus-bus skipped`,
+      );
+    } else {
+      registerTerminalFocus(props.ptyId, projectPath, () => {
+        try {
+          term?.focus();
+        } catch {
+          // ignore
+        }
+      });
+      const onTextareaFocus = () => recordTerminalFocus(props.ptyId);
+      term.textarea?.addEventListener("focus", onTextareaFocus);
+      onCleanup(() => {
+        term?.textarea?.removeEventListener("focus", onTextareaFocus);
+      });
+    }
 
     term.onData((data) => {
       void editorPty.write(props.ptyId, encoder.encode(data));

--- a/src/components/diff-panel/editor-pty-view.tsx
+++ b/src/components/diff-panel/editor-pty-view.tsx
@@ -10,6 +10,10 @@ import {
 } from "@tauri-apps/plugin-clipboard-manager";
 import { useEditorPty } from "@/context/editor-pty";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
+import {
+  registerTerminalFocus,
+  unregisterTerminalFocus,
+} from "@/lib/terminal-focus-bus";
 
 const THEME = {
   background: "#0b0b0c",
@@ -184,6 +188,14 @@ export function EditorPtyView(props: Props) {
     window.setTimeout(() => safeFit("onMount-220ms"), 220);
     window.setTimeout(() => safeFit("onMount-600ms"), 600);
 
+    registerTerminalFocus(props.ptyId, () => {
+      try {
+        term?.focus();
+      } catch {
+        // ignore
+      }
+    });
+
     term.onData((data) => {
       void editorPty.write(props.ptyId, encoder.encode(data));
     });
@@ -286,6 +298,7 @@ export function EditorPtyView(props: Props) {
 
   onCleanup(() => {
     disposed = true;
+    unregisterTerminalFocus(props.ptyId);
     resizeObs?.disconnect();
     if (fitDebounce) window.clearTimeout(fitDebounce);
     detachData?.();

--- a/src/components/shell-terminal/shell-terminal-panel.tsx
+++ b/src/components/shell-terminal/shell-terminal-panel.tsx
@@ -11,6 +11,7 @@ import { Plus, X } from "lucide-solid";
 import { useShellPty } from "@/context/shell-pty";
 import { useShellPanel } from "@/context/shell-panel";
 import { ShellTerminalView } from "./shell-terminal-view";
+import { focusTerminal } from "@/lib/terminal-focus-bus";
 
 type Props = {
   projectPath: string;
@@ -67,7 +68,12 @@ export function ShellTerminalPanel(props: Props) {
   }
 
   function handleNewTab() {
-    void pty.openTab(props.projectPath);
+    void pty.openTab(props.projectPath).then((id) => {
+      // User-action focus: opening a new tab is an explicit "I want to type
+      // here" gesture. focusTerminal queues if the view hasn't mounted yet
+      // and fires as soon as it registers. See PRP 017 / #40.
+      focusTerminal(id);
+    });
   }
 
   function handleCloseTab(ptyId: string, ev: MouseEvent) {
@@ -77,6 +83,7 @@ export function ShellTerminalPanel(props: Props) {
 
   function handleActivate(ptyId: string) {
     pty.setActiveForProject(props.projectPath, ptyId);
+    focusTerminal(ptyId);
   }
 
   // --- Vertical resize (drag top edge). Pointer-based — same pattern the

--- a/src/components/shell-terminal/shell-terminal-view.tsx
+++ b/src/components/shell-terminal/shell-terminal-view.tsx
@@ -14,6 +14,10 @@ import {
   registerTerminalScroller,
   unregisterTerminalScroller,
 } from "@/lib/terminal-scroll-bus";
+import {
+  registerTerminalFocus,
+  unregisterTerminalFocus,
+} from "@/lib/terminal-focus-bus";
 import { ScrollToBottomButton } from "@/components/scroll-to-bottom-button";
 
 const THEME = {
@@ -176,6 +180,13 @@ export function ShellTerminalView(props: Props) {
       setIsScrolledUp(buf.viewportY < buf.baseY);
     });
     registerTerminalScroller(props.ptyId, scrollToBottom);
+    registerTerminalFocus(props.ptyId, () => {
+      try {
+        term?.focus();
+      } catch {
+        // ignore
+      }
+    });
 
     detachData = ctx.onData(props.ptyId, (bytes) => {
       if (disposed) return;
@@ -248,6 +259,7 @@ export function ShellTerminalView(props: Props) {
     detachExit?.();
     scrollDisposable?.dispose();
     unregisterTerminalScroller(props.ptyId);
+    unregisterTerminalFocus(props.ptyId);
     try {
       term?.dispose();
     } catch (err) {

--- a/src/components/shell-terminal/shell-terminal-view.tsx
+++ b/src/components/shell-terminal/shell-terminal-view.tsx
@@ -15,6 +15,7 @@ import {
   unregisterTerminalScroller,
 } from "@/lib/terminal-scroll-bus";
 import {
+  recordTerminalFocus,
   registerTerminalFocus,
   unregisterTerminalFocus,
 } from "@/lib/terminal-focus-bus";
@@ -180,13 +181,28 @@ export function ShellTerminalView(props: Props) {
       setIsScrolledUp(buf.viewportY < buf.baseY);
     });
     registerTerminalScroller(props.ptyId, scrollToBottom);
-    registerTerminalFocus(props.ptyId, () => {
-      try {
-        term?.focus();
-      } catch {
-        // ignore
-      }
-    });
+    const projectPath = ctx.getTab(props.ptyId)?.projectPath;
+    if (!projectPath) {
+      console.error(
+        `shell-terminal-view: no projectPath for ${props.ptyId}; focus-bus skipped`,
+      );
+    } else {
+      registerTerminalFocus(props.ptyId, projectPath, () => {
+        try {
+          term?.focus();
+        } catch {
+          // ignore
+        }
+      });
+      // Track focus moves driven by direct clicks on the xterm body (which
+      // focus the hidden textarea natively). Keeps lastFocusedForProject
+      // current even when the bus isn't called.
+      const onTextareaFocus = () => recordTerminalFocus(props.ptyId);
+      term.textarea?.addEventListener("focus", onTextareaFocus);
+      onCleanup(() => {
+        term?.textarea?.removeEventListener("focus", onTextareaFocus);
+      });
+    }
 
     detachData = ctx.onData(props.ptyId, (bytes) => {
       if (disposed) return;

--- a/src/components/shell-terminal/shell-terminal-view.tsx
+++ b/src/components/shell-terminal/shell-terminal-view.tsx
@@ -219,7 +219,14 @@ export function ShellTerminalView(props: Props) {
     onCleanup(() => window.removeEventListener("resize", onWinResize));
   });
 
-  // Same visibility re-fit + refresh + focus dance as the Claude terminal.
+  // Visibility re-fit + refresh on activation. Intentionally NOT calling
+  // term.focus() here: the shell is a secondary surface that lives next to
+  // the Claude tab, and on project re-entry both panels' selected tabs flip
+  // active=true simultaneously. If shell focuses inside its rAF, it lands
+  // *after* Claude's synchronous focus and steals the cursor — typing then
+  // hits whatever is running in the shell (e.g. `npm run dev`). See PRP 017
+  // / #40. The xterm canvas click handler still focuses on direct clicks,
+  // so the only regression is clicking the tab strip header.
   createEffect(() => {
     if (!props.active) return;
     requestAnimationFrame(() => {
@@ -227,7 +234,6 @@ export function ShellTerminalView(props: Props) {
       safeFit();
       try {
         if (term) term.refresh(0, term.rows - 1);
-        term?.focus();
       } catch {
         // ignore
       }

--- a/src/components/terminal-view.tsx
+++ b/src/components/terminal-view.tsx
@@ -17,6 +17,11 @@ import {
   registerTerminalScroller,
   unregisterTerminalScroller,
 } from "@/lib/terminal-scroll-bus";
+import {
+  recordTerminalFocus,
+  registerTerminalFocus,
+  unregisterTerminalFocus,
+} from "@/lib/terminal-focus-bus";
 import { ScrollToBottomButton } from "@/components/scroll-to-bottom-button";
 
 const THEME = {
@@ -229,6 +234,29 @@ export function TerminalView(props: Props) {
       setIsScrolledUp(buf.viewportY < buf.baseY);
     });
     registerTerminalScroller(props.id, scrollToBottom);
+    // Bail on focus-bus registration if the tab isn't in the store yet —
+    // that would indicate a real invariant violation (parent renders the
+    // view by iterating the store), and registering under "" would
+    // cross-contaminate per-project memory across projects.
+    const projectPath = ctx.getTab(props.id)?.projectPath;
+    if (!projectPath) {
+      console.error(
+        `terminal-view: no projectPath for ${props.id}; focus-bus skipped`,
+      );
+    } else {
+      registerTerminalFocus(props.id, projectPath, () => {
+        try {
+          term?.focus();
+        } catch {
+          // ignore
+        }
+      });
+      const onTextareaFocus = () => recordTerminalFocus(props.id);
+      term.textarea?.addEventListener("focus", onTextareaFocus);
+      onCleanup(() => {
+        term?.textarea?.removeEventListener("focus", onTextareaFocus);
+      });
+    }
 
     detachData = ctx.onData(props.id, (bytes) => {
       term?.write(bytes);
@@ -294,12 +322,17 @@ export function TerminalView(props: Props) {
   //      and occasionally leaking the welcome banner from the previous-
   //      screen scrollback. One late fit keeps the eventual size correct
   //      while limiting Claude to at most one re-paint. See PRP 016 / #38.
+  //
+  // Intentionally NOT calling term.focus() here: project re-entry is a
+  // passive activation, not a user action. App.tsx's project-switch effect
+  // calls focusTerminal(lastFocusedForProject(p) ?? activeClaudeId) once,
+  // so the surface the user was actually using last in this project takes
+  // the cursor — Claude, shell, or editor PTY. See PRP 017 v1.2 / #40.
   createEffect(() => {
     if (!props.active) return;
 
     try {
       if (term) term.refresh(0, term.rows - 1);
-      term?.focus();
     } catch {
       // refresh failures shouldn't block the activation flow.
     }
@@ -319,6 +352,7 @@ export function TerminalView(props: Props) {
     linkDisposable?.dispose();
     scrollDisposable?.dispose();
     unregisterTerminalScroller(props.id);
+    unregisterTerminalFocus(props.id);
     term?.dispose();
     // NOTE: intentionally NOT calling ctx.closeTab here — unmounting the view
     // (e.g. changing project) is separate from killing the PTY. The shell owns

--- a/src/lib/terminal-focus-bus.ts
+++ b/src/lib/terminal-focus-bus.ts
@@ -1,0 +1,53 @@
+// Tiny module-level registry that lets tab-strip + new-tab handlers ask a
+// specific terminal to take keyboard focus. Sibling of `terminal-scroll-bus`.
+//
+// Why a registry instead of letting each view focus itself on activation?
+// On project re-entry every visible panel's selected tab flips active=true
+// simultaneously; if every view called `term.focus()` from its activation
+// effect, the last one to run would steal the cursor from the others (see
+// #40 / PRP 017). We solve that by only focusing on **explicit user actions**
+// — clicking "+" or a tab header — routed through this bus. Passive
+// activations (project switch, auto-resume, auto-spawn) don't go through
+// here and therefore don't steal focus.
+//
+// IDs are PTY ids (UUIDs), unique across Claude, shell, and editor PTYs.
+
+const focusers = new Map<string, () => void>();
+const pending = new Map<string, number>();
+
+export function registerTerminalFocus(id: string, fn: () => void): void {
+  focusers.set(id, fn);
+  const timer = pending.get(id);
+  if (timer !== undefined) {
+    window.clearTimeout(timer);
+    pending.delete(id);
+    fn();
+  }
+}
+
+export function unregisterTerminalFocus(id: string): void {
+  focusers.delete(id);
+  const timer = pending.get(id);
+  if (timer !== undefined) {
+    window.clearTimeout(timer);
+    pending.delete(id);
+  }
+}
+
+/** Focus the terminal with the given PTY id. If the view hasn't mounted yet
+ *  (newly-created tab), the request is queued and fires as soon as the view
+ *  registers — within a 500ms window. Beyond that the pending entry expires,
+ *  on the assumption the tab failed to spawn. */
+export function focusTerminal(id: string | null): void {
+  if (!id) return;
+  const fn = focusers.get(id);
+  if (fn) {
+    fn();
+    return;
+  }
+  if (pending.has(id)) return;
+  const timer = window.setTimeout(() => {
+    pending.delete(id);
+  }, 500);
+  pending.set(id, timer);
+}

--- a/src/lib/terminal-focus-bus.ts
+++ b/src/lib/terminal-focus-bus.ts
@@ -1,36 +1,64 @@
 // Tiny module-level registry that lets tab-strip + new-tab handlers ask a
-// specific terminal to take keyboard focus. Sibling of `terminal-scroll-bus`.
+// specific terminal to take keyboard focus, and remembers per-project which
+// terminal had focus last so project re-entry can restore it. Sibling of
+// `terminal-scroll-bus`.
 //
 // Why a registry instead of letting each view focus itself on activation?
 // On project re-entry every visible panel's selected tab flips active=true
 // simultaneously; if every view called `term.focus()` from its activation
-// effect, the last one to run would steal the cursor from the others (see
-// #40 / PRP 017). We solve that by only focusing on **explicit user actions**
-// — clicking "+" or a tab header — routed through this bus. Passive
-// activations (project switch, auto-resume, auto-spawn) don't go through
-// here and therefore don't steal focus.
+// effect, the last one to run would steal the cursor from the others (#40).
+// We solve that by only focusing on **explicit user actions** — clicking
+// "+" or a tab header, opening a file in an editor PTY — routed through
+// this bus, plus a one-shot focus on project switch driven by the
+// `lastFocusedForProject` memory below.
+//
+// The per-project memory is updated in two places:
+//   1. Inside `focusTerminal` when the call succeeds (covers user-action
+//      activations: "+" / tab header click / Open-in).
+//   2. From `recordTerminalFocus`, which views call from a `focus` event
+//      listener on `term.textarea`. That catches direct clicks on the
+//      xterm body (xterm's native canvas → textarea focus path) as well
+//      as anything else that ends up focusing the textarea.
 //
 // IDs are PTY ids (UUIDs), unique across Claude, shell, and editor PTYs.
 
-const focusers = new Map<string, () => void>();
-const pending = new Map<string, number>();
+type FocusEntry = {
+  fn: () => void;
+  projectPath: string;
+};
 
-export function registerTerminalFocus(id: string, fn: () => void): void {
-  focusers.set(id, fn);
+const focusers = new Map<string, FocusEntry>();
+const pending = new Map<string, number>();
+const lastFocusedByProject = new Map<string, string>();
+
+export function registerTerminalFocus(
+  id: string,
+  projectPath: string,
+  fn: () => void,
+): void {
+  focusers.set(id, { fn, projectPath });
   const timer = pending.get(id);
   if (timer !== undefined) {
     window.clearTimeout(timer);
     pending.delete(id);
     fn();
+    lastFocusedByProject.set(projectPath, id);
   }
 }
 
 export function unregisterTerminalFocus(id: string): void {
+  const entry = focusers.get(id);
   focusers.delete(id);
   const timer = pending.get(id);
   if (timer !== undefined) {
     window.clearTimeout(timer);
     pending.delete(id);
+  }
+  // If the terminal that owned "last focused" for its project just went
+  // away, drop the record. Next project switch will fall back to the
+  // active Claude tab.
+  if (entry && lastFocusedByProject.get(entry.projectPath) === id) {
+    lastFocusedByProject.delete(entry.projectPath);
   }
 }
 
@@ -40,9 +68,10 @@ export function unregisterTerminalFocus(id: string): void {
  *  on the assumption the tab failed to spawn. */
 export function focusTerminal(id: string | null): void {
   if (!id) return;
-  const fn = focusers.get(id);
-  if (fn) {
-    fn();
+  const entry = focusers.get(id);
+  if (entry) {
+    entry.fn();
+    lastFocusedByProject.set(entry.projectPath, id);
     return;
   }
   if (pending.has(id)) return;
@@ -50,4 +79,17 @@ export function focusTerminal(id: string | null): void {
     pending.delete(id);
   }, 500);
   pending.set(id, timer);
+}
+
+/** Update the per-project memory without calling focus(). Views invoke this
+ *  from a `focus` listener attached to `term.textarea` so direct clicks on
+ *  the xterm body (which focus the hidden textarea natively) are tracked. */
+export function recordTerminalFocus(id: string): void {
+  const entry = focusers.get(id);
+  if (!entry) return;
+  lastFocusedByProject.set(entry.projectPath, id);
+}
+
+export function lastFocusedForProject(projectPath: string): string | undefined {
+  return lastFocusedByProject.get(projectPath);
 }


### PR DESCRIPTION
Closes #40 (both directions).

## Summary

Three commits encode a single rule across all three terminal surfaces (Claude, shell, editor PTY): **focus is only triggered by an explicit user action or by per-project memory restoration on project switch. Visibility flips never decide focus.**

**Commit 1 (`bc13c90`)** — remove `term.focus()` from `shell-terminal-view.tsx` and `editor-pty-view.tsx` activation effects. On project re-entry shell's rAF-deferred focus landed *after* Claude's synchronous focus and stole the cursor, sending keystrokes into whatever was running in the shell (#40 original direction).

**Commit 2 (`d72a1b8`)** — add `src/lib/terminal-focus-bus.ts` (sibling of `terminal-scroll-bus`) and wire user-action handlers (shell "+", shell tab click, editor "Open in" new/existing, editor tab click) to call `focusTerminal(id)`. Newly-created tabs are queued for ≤500ms and focused on registration.

**Commit 3 (`3d9e46e`)** — close the inverse: if user was typing in shell A, switched away and back, Claude's activation effect was still stealing the cursor. Make the rule consistent — remove Claude's activation focus, register Claude in the focus-bus, attach `focus` listeners on every view's `term.textarea` so direct xterm body clicks update `lastFocusedByProject`. App.tsx's project-switch effect now calls `focusTerminal(lastFocusedForProject(p) ?? nextActive)` inside an rAF (with a guard for fast re-switching).

## Final call-site matrix

| Trigger | Where the focus call lives |
| --- | --- |
| Project switch in (memory restore) | `App.tsx` project-switch effect (rAF) |
| Claude "+" | `App.tsx:openNewTab` |
| Claude session-click | `App.tsx:handleSelectSession` / `openResumeTab` |
| Claude tab click | `App.tsx:handleActivateTab` |
| Claude auto-resume | `App.tsx:maybeAutoResume` |
| Shell "+" | `shell-terminal-panel.tsx:handleNewTab` |
| Shell tab click | `shell-terminal-panel.tsx:handleActivate` |
| Editor Open-in (new + existing) | `diff-panel.tsx:dispatchAppOpen` |
| Editor tab click | `diff-panel.tsx:onActivate` |
| Direct click on xterm body | `term.textarea` focus listener → `recordTerminalFocus` (memory only) |

Still intentionally passive: shell-panel auto-spawn of first tab. No project active.

PRP at `PRPs/017--fix-focus-steal-on-project-switch.md` (v1.2).

## ⚠️ Manual QA not yet performed by me

I cannot drive the UI from here. **Typecheck passes**, and the architecture is reviewed, but the actual repro from the screenshots (and the inverse direction) has not been verified end-to-end. The third commit in particular adds new behavior (per-project memory + textarea focus listeners) that needs a real run.

### Discriminating check
After repro step (returning to a project where shell was last-focused), without clicking, paste in DevTools console:
```js
document.activeElement
```
If it's the shell's `xterm-helper-textarea`, the fix works. If it's Claude's, the per-project memory isn't getting updated by the textarea focus listener — that's the only piece of genuinely new behavior beyond v1.1.

## Test plan (manual)

### Original bug (#40 direction A)
- [ ] Project A with Claude + Shell tabs, project B Claude-only. Type into Claude A → switch to B → type into Claude B → switch back to A → next keystroke goes to **Claude A**.

### Inverse bug (#40 direction B — the screenshots)
- [ ] Project T with Claude + Shell. Run `ls -la` in shell → switch to A (do nothing) → switch back to T → next keystroke goes to **Shell** (not Claude). This is the new behavior.

### User-action focus (commit 2)
- [ ] Shell `+`: cursor lands in the new shell xterm without a click.
- [ ] Click another shell tab header: focuses that shell.
- [ ] `Open in <editor>` on a file: cursor lands in the editor PTY without a click.
- [ ] Click another editor tab header: focuses target editor PTY.
- [ ] Click a file-preview tab header: no crash, focus unchanged.

### Claude focus on user actions (commit 3 — was previously via activation effect)
- [ ] Claude `+ New session`: cursor lands in the new Claude xterm.
- [ ] Click a session in the sidebar: cursor lands in Claude.
- [ ] Click between two Claude tabs in same project: focus follows.
- [ ] First-time project entry: cursor lands in the active Claude tab.
- [ ] Project entry with no tabs → auto-resume kicks in: cursor lands in the auto-resumed tab once it opens.

### No regression
- [ ] Rapid project switching: no welcome banner re-appearing, no upward scroll drift (still respects #38).
- [ ] First boot: terminal width is correct from first paint (still respects #7).
- [ ] Close the shell tab that was last-focused for a project, switch project, switch back: Claude focuses (memory cleared on unregister, falls back to active Claude tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)