### PR TITLE
feat(notifications): per-tab attention indicator + toast→tab routing (#42)

### DIFF
--- a/PRPs/018--tab-needs-attention-indicator.md
+++ b/PRPs/018--tab-needs-attention-indicator.md
@@ -1,0 +1,358 @@
+# PRP 018: Per-tab "needs attention" indicator in the tab strip
+
+> **Version:** 1.2
+> **Created:** 2026-05-14
+> **Updated:** 2026-05-15 — v1.2: toast / bell click route to the
+> originating tab, not just the project. Discovered during QA: clicking
+> the toast switched projects but landed on whatever tab was active
+> before, defeating the "which tab needs me" cue.
+> **Updated:** 2026-05-14 — advisor pass: enumerate all activation
+> paths, drop the misleading null-sessionId fallback, spell out the
+> clearTabAttention early-return.
+> **Status:** Draft
+> **Tracks:** [#42](https://github.com/willywg/klaudio-panels/issues/42)
+> **Confidence:** 8/10 — small surface (5 files), no new Rust, no new Tauri events, no new IPC. Risk concentrated in correctly enumerating every tab-activation call site (see §4).
+
+---
+
+## Goal
+
+When a project has more than one Claude tab and one of them fires a
+notification (`session:complete` or warp `permission_request`) while
+the user is looking at a different tab, the tab strip paints an amber
+pulse on the dot of the offending tab. The flag clears when the user
+activates that tab, types into it, or closes it. Single-tab projects
+get no indicator — the project-level amber ring already disambiguates.
+
+## Why
+
+Notifications today are project-scoped: the project avatar gets the
+amber ring, the bell records the event, and an OS banner fires when
+blurred. Inside a multi-tab project the user has to click each tab to
+find the one Claude is asking about. Extending the existing per-tab
+status dot (`tab-strip.tsx:14-25`) is the lowest-noise place to land
+the "this tab" signal — same visual idiom, same palette family as the
+amber permission toast (`notification-toast.tsx:28`).
+
+## What changes
+
+### 1. New tab state — `needsAttention`
+
+`TerminalTab` (in `src/context/terminal.tsx:13-24`) gains:
+
+```ts
+needsAttention: boolean
+```
+
+Default `false`. Owned by `terminal.tsx` because tabs already live
+there; this avoids a parallel `Set<tabId>` in `notifications.tsx` that
+would need to listen to tab disposal for cleanup.
+
+Two new methods exported from `useTerminal()`:
+
+```ts
+function markTabNeedsAttention(id: string) {
+  const tab = store.tabs.find((t) => t.id === id);
+  if (!tab || tab.needsAttention) return;
+  setStore("tabs", (t) => t.id === id, "needsAttention", true);
+}
+
+function clearTabAttention(id: string) {
+  const tab = store.tabs.find((t) => t.id === id);
+  if (!tab || !tab.needsAttention) return;
+  setStore("tabs", (t) => t.id === id, "needsAttention", false);
+}
+```
+
+The early-return is **load-bearing**: `clearTabAttention` is called
+on every xterm `onData` keystroke; without the guard, Solid's
+reactive graph dirties on every char even when there's nothing to
+clear, dragging dependent memos with it.
+
+Both are no-ops when the id is unknown. `closeTab` doesn't need to
+clear explicitly — splicing the tab out of the store drops the flag
+with it.
+
+### 2. Wire `notifications.tsx` to the terminal store
+
+`NotificationsProvider` is mounted INSIDE `TerminalProvider` (see
+`App.tsx:1056-1063`), so it can `useTerminal()` directly. No new
+resolver method, no new prop drilling.
+
+Add two helpers next to `alertProject`:
+
+```ts
+// Decide whether the event should raise a per-tab flag and which
+// tab to flag. Returns null when no flag should be raised (single-
+// tab project, no sessionId match, user is on the tab).
+function pickAttentionTarget(
+  projectPath: string,
+  sessionId: string | null,
+): string | null {
+  const tabs = term.store.tabs.filter((t) => t.projectPath === projectPath);
+  if (tabs.length <= 1) return null;             // single-tab gate
+  if (!sessionId) return null;                   // no reliable target
+  const target = tabs.find((t) => t.sessionId === sessionId);
+  if (!target) return null;
+  // Suppress if user is literally looking at it: window focused AND
+  // project active AND this tab is its active tab. Same condition
+  // shape as `alertProject`'s `here` check. Note: when activeTabId
+  // is null (project just opened, no tab picked yet) the equality
+  // is false, so the flag is raised — intentional, the user hasn't
+  // committed to a tab.
+  const here =
+    focused() &&
+    resolver.isActiveProject(projectPath) &&
+    term.store.activeTabId === target.id;
+  if (here) return null;
+  return target.id;
+}
+```
+
+**Why drop the null-sessionId fallback.** v1.0 of this PRP fell back
+to "flag the project's currently-active tab" when sessionId was null.
+That's actively misleading in the common case where the project
+*isn't* active: `term.store.activeTabId` is global, so a null-sid
+event on project A while the user is on project B would land the dot
+on project A's leftmost tab — almost certainly not the tab Claude
+is asking about. A wrong-tab pulse is worse than no pulse: it
+trains the user to distrust the signal. The project ring + toast +
+bell still fire, so the user knows project A wants something — they
+just have to look. The fallback was a half-measure; cutting it
+costs nothing on warp ≥0.3.0 (which sends session_id reliably) and
+avoids the misleading-pulse failure mode on older warp builds.
+
+Called from `handleComplete` and `handleAgentEvent`, AFTER the existing
+prefs gate (so disabling `notifySessionComplete` / `notifyPermission`
+also disables the dot — the issue calls this out explicitly):
+
+```ts
+function handleComplete(payload: SessionCompletePayload) {
+  if (!prefs().notifySessionComplete) return;
+  // ...existing alert + sound...
+  const tabId = pickAttentionTarget(payload.project_path, payload.session_id);
+  if (tabId) term.markTabNeedsAttention(tabId);
+}
+
+function handleAgentEvent(payload: CliAgentEvent) {
+  if (payload.event !== "permission_request") return;
+  if (!prefs().notifyPermission) return;
+  const projectPath = resolver.resolveOpenProject(payload.cwd);
+  if (!projectPath) return;
+  // ...existing alert + sound...
+  const tabId = pickAttentionTarget(projectPath, payload.session_id);
+  if (tabId) term.markTabNeedsAttention(tabId);
+}
+```
+
+### 3. Tab-strip render
+
+`statusDotClass` (`src/components/tab-strip.tsx:14-25`) takes
+precedence on `needsAttention` over the underlying PTY status:
+
+```ts
+function statusDotClass(tab: TerminalTab): string {
+  if (tab.needsAttention) return "bg-amber-400 animate-pulse";
+  switch (tab.status) {
+    case "opening": return "bg-indigo-400 animate-pulse";
+    case "running": return "bg-green-500";
+    case "exited":  return "bg-neutral-500";
+    case "error":   return "bg-red-500";
+  }
+}
+```
+
+The function now takes the whole tab instead of just `status`. Caller
+at `tab-strip.tsx:46` updates accordingly.
+
+### 4. Reset hooks — every tab-activation path
+
+The rule: any user action that **activates a tab** clears its
+attention flag. Project-switch effect's `term.setActiveTab(nextActive)`
+is the one activation path that must NOT clear (project switch is
+coarser than the per-tab signal). That contract forbids putting the
+clear inside `setActiveTab` itself — we'd lose the project-switch
+exception — so we enumerate the user-action call sites explicitly,
+mirroring the focus-bus pattern from PRP 017.
+
+Every call site that activates a tab in response to a user gesture:
+
+| Trigger | File / handler | Action |
+| --- | --- | --- |
+| Tab-strip click | `App.tsx:handleActivateTab` | `clearTabAttention(id)` before `setActiveTab` |
+| Sidebar session-click on an already-open tab | `App.tsx:handleSelectSession` (the `if (existing) {...}` branch around line 605) | `clearTabAttention(existing.id)` before `setActiveTab` |
+| Command palette session-select on an already-open tab | Same code path — `CommandPalette` calls `onSelectSession` which is `handleSelectSession`. Covered by the line above. | — |
+| Sidebar session-click that opens a fresh resume tab | `App.tsx:openResumeTab` (via `openTab`) | No action needed — new tab boots with `needsAttention: false`. |
+| Cmd+T new tab | `App.tsx:openNewTab` | Same — new tab boots clean. |
+| Cmd+1..9 project switch | `App.tsx` keybind → `setActiveProjectPath` | No action — project switch must not clear (see §QA #10). |
+| User types into the active Claude xterm | `terminal-view.tsx` xterm `onData` handler | `clearTabAttention(id)` once at the top |
+| Tab closes | `terminal.tsx:closeTab` | Free — splicing the tab drops the flag |
+
+The xterm `onData` reset is belt-and-suspenders alongside the
+activation clears: it catches the rare case where the user types
+into an already-active tab whose flag was set by a `session:complete`
+that arrived *after* activation (race: tab was active, blur stole
+the window, completion fired, focus returns, user types). The early
+return in `clearTabAttention` keeps this cheap.
+
+## Trade-offs
+
+- **Null-sessionId `permission_request` raises no per-tab flag**
+  (see §2 reasoning). Project ring + toast + bell still fire. Warp
+  ≥0.3.0 sends `session_id`, so this only affects users on very old
+  plugin builds.
+- **Unpromoted-tab race**: a fresh `claude` tab spawns with
+  `sessionId: null` and gets promoted by the session watcher once the
+  JSONL file appears (debounce ~200ms). If `session:complete` arrives
+  before promotion — fast run, slow watcher — `pickAttentionTarget`
+  finds no matching tab and returns null. No per-tab pulse for that
+  event; project ring + toast + bell still fire. Hard to hit in
+  practice (a real Claude run is longer than the debounce); not
+  worth a fallback.
+- **No badge count** — out of scope per the issue. A single pulse per
+  tab is enough; a counter creates more noise than signal for a
+  desktop app that's expected to be foreground most of the time.
+- **No sidebar avatar tab-level surface** — the project avatar already
+  rings amber. The issue explicitly excludes this.
+- **No persistence** — restarting Klaudio drops all `needsAttention`
+  flags. Same model as the bell's `unreadItems` (see
+  `notifications.tsx:124`). A fresh app start is a clean slate.
+
+## QA checklist
+
+Manual, in `bun tauri dev`. All cases assume `notifySessionComplete`
+and `notifyPermission` are enabled (settings default).
+
+1. **Single-tab project — no flag**: open a project with one Claude
+   tab. Send it to do something that ends with `session:complete`.
+   Confirm: amber project ring fires; tab dot stays green (running)
+   or neutral (exited). No pulse.
+2. **Multi-tab session:complete on inactive tab**: open two tabs in
+   project A. Switch to tab 2. Tab 1's session finishes. Confirm:
+   tab 1 dot is amber + pulsing. Tab 2 unchanged. Project A ring
+   suppressed because focused + active.
+3. **Multi-tab session:complete on active tab**: tab 1 active, tab 1
+   itself completes. Confirm: no pulse (user is here).
+4. **Multi-tab permission_request with session_id**: tab 1 = `claude
+   --resume X`, tab 2 = `claude --resume Y`. From within tab 2 trigger
+   a permission prompt (e.g. an `Edit` tool call). Confirm: tab 2 dot
+   amber if tab 1 is active. Switch to tab 2 — clears.
+5. **Permission_request with null session_id** (older warp build, if
+   reproducible): no per-tab pulse anywhere. Project ring + toast +
+   bell still fire normally.
+6. **Clear by tab-strip click**: pulse on tab 1, click tab 1 in the
+   strip. Pulse clears, dot returns to underlying PTY status color.
+7. **Clear by sidebar session-click on an open tab**: tab 1 has a
+   pulse and corresponds to session X. Click session X's row in the
+   Sessions sidebar (which routes through `handleSelectSession` and
+   takes the `existing` branch). Pulse clears.
+8. **Clear by command palette session-select**: same as #7 but via
+   Cmd+K → pick the session. Pulse clears (same handler).
+9. **Clear by typing**: rare race — tab 1 is already active when its
+   completion fires (e.g. window was blurred when the event arrived,
+   so suppression didn't apply). Pulse appears on the active tab.
+   Type one character. Pulse clears.
+10. **Close clears**: pulse on tab 1, close tab 1 with the X button.
+    No crash, no orphaned amber state.
+11. **Prefs kill switch**: disable `notifySessionComplete` in
+    settings. Repeat scenario 2. Confirm: no toast AND no tab pulse.
+    Same for `notifyPermission` + scenario 4.
+12. **Project switch does NOT clear**: in project A's tab 1, get a
+    pulse. Switch to project B, switch back to project A. The pulse
+    on tab 1 should still be there (the user hasn't acknowledged the
+    specific tab yet). Project A's ring should clear (existing
+    behavior — `notifications.markRead(p)` in the active-path effect).
+
+## Out of scope
+
+- Notification COUNT badge per tab.
+- Cross-project tab surfacing on the projects sidebar avatar.
+- Sound differentiation per tab.
+- Persisting flags across app restarts.
+- Showing a tooltip on the pulsing dot ("Claude finished" / "Needs
+  permission"). The toast + bell already carry the wording.
+
+## v1.2 addendum — toast / bell click routes to the originating tab
+
+**Why**: v1.1 painted the pulse correctly but the toast click handler
+only called `resolver.activateProject(projectPath)`. The project-switch
+effect then picked the active tab via `activeByProject` memory — which
+is the tab the user had open *before* the alert, not the tab that fired
+the alert. So clicking the toast for "Project A · Claude is done" while
+sitting in tab 1 landed you back on tab 1, with tab 2 still pulsing.
+
+**The fix**: pass the originating tab through the toast and bell.
+
+1. **`Toast` and `UnreadItem` gain `tabId: string | null`**. Null when
+   `sessionId` was missing (older warp builds) or no open tab matched.
+   In that case routing degrades gracefully — clicking still activates
+   the project, just without preselecting a tab.
+
+2. **`findTabForEvent(projectPath, sessionId)`** — the pure
+   payload→tab mapping. Used by BOTH the toast routing and the
+   pulse-raising path. Split from the old `pickAttentionTarget` so the
+   pulse gate (`shouldRaisePulse`) doesn't suppress toast routing —
+   single-tab projects still get routed (no ambiguity, but the toast
+   target should still activate that one tab), and "user is here" still
+   gets routed (toast was enqueued anyway when focused; clicking it
+   should always do something).
+
+3. **`shouldRaisePulse(projectPath, tabId)`** — the gate that used to
+   live inside `pickAttentionTarget`. Owns the single-tab-suppression
+   and the "user is looking at it" suppression.
+
+4. **`ProjectResolver.activateTab(projectPath, tabId)`** — new resolver
+   method implemented in `App.tsx`:
+   - Same project as currently active: `term.clearTabAttention(tabId)`
+     + `term.setActiveTab(tabId)` + `focusTerminal(tabId)`. The
+     project-switch effect doesn't fire, so we clear / activate /
+     focus directly.
+   - Different project: `activeByProject.set(projectPath, tabId)` first
+     so the project-switch effect's "remembered tab" lookup picks our
+     target, then `setActiveProjectPath(projectPath)`. The effect
+     handles focus via `lastFocusedForProject` memory. Acceptable
+     trade-off — if the user was last in a shell/editor for that
+     project, focus follows them there, but the Claude tab is still
+     visible and its pulse is cleared.
+
+5. **`activateAndDismiss` (toast) and `activateProjectFromBell` (bell)**
+   dispatch through `activateTab` when `tabId` is set, else fall back
+   to `activateProject`.
+
+**Files touched in v1.2**: `notifications.tsx` (types + helpers +
+handlers + resolver type + activateAndDismiss + activateProjectFromBell),
+`App.tsx` (resolver impl), `notification-bell.tsx` (one-liner: pass
+`item.tabId` through).
+
+**QA added**:
+
+13. **Toast click routes to tab — same project**: 2 tabs in project A,
+    tab 1 active. Tab 2 fires session:complete. Toast appears. Click
+    the toast. Tab 2 activates, pulse clears, no project switch.
+14. **Toast click routes to tab — cross project**: project A has tab 2
+    pulsing, user is in project B. Click the toast. Project switches to
+    A, tab 2 activates, pulse clears.
+15. **Bell click routes to tab**: same as #13/14 via bell entries.
+16. **Null-tabId graceful fallback**: simulate a null-sessionId
+    `permission_request` (warp <0.3.0). Toast click activates the
+    project without preselecting any tab. No crash.
+
+## Risk
+
+Low. Four files touched:
+
+- `src/context/terminal.tsx` — adds one field + two methods.
+- `src/context/notifications.tsx` — adds `pickAttentionTarget` and two
+  call sites; reads `useTerminal()`.
+- `src/components/tab-strip.tsx` — one function signature change.
+- `src/App.tsx` — one extra call in `handleActivateTab`.
+- `src/components/terminal-view.tsx` — one extra call in `onData`.
+
+No Rust, no new Tauri commands, no event-channel additions. The
+existing PTY/notification/session-watcher pipelines are untouched.
+
+The only sharp edge is the provider ordering: `NotificationsProvider`
+must remain INSIDE `TerminalProvider` (already is, see
+`App.tsx:1056-1063`). If a future refactor flips the order, the
+`useTerminal()` call inside notifications will throw on mount. A
+comment at the call site documenting the dependency is enough.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,6 +198,24 @@ function Shell() {
       return best;
     },
     activateProject: (projectPath) => setActiveProjectPath(projectPath),
+    /// Toast / bell click with a known origin tab. Two paths:
+    ///   - Same project: switch tab + focus + clear pulse directly.
+    ///   - Different project: pre-mark activeByProject so the project-
+    ///     switch effect picks this tab as `nextActive`, then trigger
+    ///     the switch. The effect handles focus via lastFocusedForProject
+    ///     memory, which is fine — if the user was last in shell/editor
+    ///     for that project, focus follows them there; the target tab
+    ///     is still visible and its pulse is cleared.
+    activateTab: (projectPath, tabId) => {
+      term.clearTabAttention(tabId);
+      if (activeProjectPath() === projectPath) {
+        term.setActiveTab(tabId);
+        focusTerminal(tabId);
+      } else {
+        activeByProject.set(projectPath, tabId);
+        setActiveProjectPath(projectPath);
+      }
+    },
   });
 
   // On active project change, pick the right tab to show (remembered > first
@@ -602,6 +620,11 @@ function Shell() {
       (t) => t.projectPath === p && t.sessionId === meta.id,
     );
     if (existing) {
+      // User-action tab activation clears the "needs attention" pulse.
+      // Project-switch effect's setActiveTab call (App.tsx ~228) must
+      // NOT clear, which is why the clear lives at the call site, not
+      // inside term.setActiveTab. See PRP 018 §4.
+      term.clearTabAttention(existing.id);
       term.setActiveTab(existing.id);
       focusTerminal(existing.id);
       return;
@@ -610,6 +633,7 @@ function Shell() {
   }
 
   function handleActivateTab(id: string) {
+    term.clearTabAttention(id);
     term.setActiveTab(id);
     focusTerminal(id);
   }

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -58,7 +58,7 @@ export function NotificationBell() {
   });
 
   function handleItemClick(item: UnreadItem) {
-    notifications.activateProjectFromBell(item.projectPath);
+    notifications.activateProjectFromBell(item.projectPath, item.tabId);
     setOpen(false);
   }
 

--- a/src/components/tab-strip.tsx
+++ b/src/components/tab-strip.tsx
@@ -11,8 +11,12 @@ type Props = {
   canOpenNew: boolean;
 };
 
-function statusDotClass(status: TerminalTab["status"]): string {
-  switch (status) {
+function statusDotClass(tab: TerminalTab): string {
+  // needsAttention wins over the PTY status colour — a tab that's
+  // running normally AND just fired a notification should pulse amber,
+  // not stay green. Cleared by activation / typing / close (PRP 018 §4).
+  if (tab.needsAttention) return "bg-amber-400 animate-pulse";
+  switch (tab.status) {
     case "opening":
       return "bg-indigo-400 animate-pulse";
     case "running":
@@ -44,7 +48,7 @@ export function TabStrip(props: Props) {
               <span
                 class={
                   "inline-block w-1.5 h-1.5 rounded-full shrink-0 " +
-                  statusDotClass(tab.status)
+                  statusDotClass(tab)
                 }
               />
               <span class="truncate flex-1">{tab.label}</span>

--- a/src/components/terminal-view.tsx
+++ b/src/components/terminal-view.tsx
@@ -152,6 +152,14 @@ export function TerminalView(props: Props) {
       // flips to raw mode. Claude doesn't actually need these pings, so
       // we just never forward them.
       if (data === "\x1b[I" || data === "\x1b[O") return;
+      // Real keystroke / paste — the user is attending this tab, so clear
+      // any pending "needs attention" pulse. clearTabAttention has an
+      // early-return when the flag is already false, so this is cheap on
+      // the hot path (PRP 018 §1). Belt-and-suspenders next to the clear
+      // in App.tsx:handleActivateTab — covers the race where the flag is
+      // raised AFTER the tab is already active (window was blurred when
+      // the event fired, focus returns, user types).
+      ctx.clearTabAttention(props.id);
       void ctx.write(props.id, encoder.encode(data));
     });
     term.onResize(({ cols, rows }) => {

--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -16,6 +16,7 @@ import {
   setPrefs,
   type NotificationPrefs,
 } from "@/lib/notifications-prefs";
+import { useTerminal } from "@/context/terminal";
 
 type SessionCompletePayload = {
   project_path: string;
@@ -51,6 +52,11 @@ export type Toast = {
   id: number;
   kind: ToastKind;
   projectPath: string;
+  /** Tab the event came from, when we could resolve it from the
+   *  payload's sessionId. Null when sessionId was missing (older warp
+   *  builds) or no open tab matched — in which case clicking the toast
+   *  just activates the project without preselecting a tab. */
+  tabId: string | null;
   title: string;
   body: string;
 };
@@ -62,6 +68,9 @@ export type UnreadItem = {
   id: number;
   kind: ToastKind;
   projectPath: string;
+  /** Same routing target as Toast.tabId — bell items click straight to
+   *  the originating tab when known. */
+  tabId: string | null;
   title: string;
   body: string;
   createdAt: number;
@@ -84,10 +93,17 @@ export type UnreadItem = {
 /// - `activateProject(path)`: switches the active project, used by the
 ///   toast click handler. The host's project-switch effect already
 ///   runs `markRead(path)` so the amber ring clears as a side effect.
+///
+/// - `activateTab(path, tabId)`: like `activateProject` but also makes
+///   `tabId` the active tab. Cross-project case pre-marks
+///   `activeByProject` so the project-switch effect picks it; same-
+///   project case calls `setActiveTab` directly. Used by toast / bell
+///   click when we know which tab the event came from.
 type ProjectResolver = {
   isActiveProject: (projectPath: string) => boolean;
   resolveOpenProject: (cwd: string | null) => string | null;
   activateProject: (projectPath: string) => void;
+  activateTab: (projectPath: string, tabId: string) => void;
 };
 
 const MAX_VISIBLE_TOASTS = 5;
@@ -106,6 +122,13 @@ function autoDismissMs(kind: ToastKind): number {
 }
 
 function makeNotificationsContext() {
+  // Pull the terminal store so we can route per-tab "needs attention"
+  // flags on session:complete / permission_request. NotificationsProvider
+  // is mounted inside TerminalProvider (see App.tsx tree), so this lookup
+  // is always defined. If a future refactor flips the order, useTerminal
+  // will throw on mount — keep this dependency in mind.
+  const term = useTerminal();
+
   // `unread` carries the steady amber ring on each project's avatar.
   // Cleared only when the user activates the project (markRead).
   const [unread, setUnread] = createSignal<ReadonlySet<string>>(new Set());
@@ -156,6 +179,7 @@ function makeNotificationsContext() {
     isActiveProject: () => false,
     resolveOpenProject: () => null,
     activateProject: () => {},
+    activateTab: () => {},
   };
 
   function setProjectResolver(next: ProjectResolver) {
@@ -248,13 +272,24 @@ function makeNotificationsContext() {
     // Activating routes through the App's project-switch effect, which
     // calls markRead → clearProjectItems. We still clear here defensively
     // in case the resolver is ever wired to a no-op (early-mount).
-    resolver.activateProject(toast.projectPath);
+    if (toast.tabId) {
+      resolver.activateTab(toast.projectPath, toast.tabId);
+    } else {
+      resolver.activateProject(toast.projectPath);
+    }
     clearProjectItems(toast.projectPath);
     dismissToast(toast.id);
   }
 
-  function activateProjectFromBell(projectPath: string) {
-    resolver.activateProject(projectPath);
+  function activateProjectFromBell(
+    projectPath: string,
+    tabId: string | null = null,
+  ) {
+    if (tabId) {
+      resolver.activateTab(projectPath, tabId);
+    } else {
+      resolver.activateProject(projectPath);
+    }
     clearProjectItems(projectPath);
   }
 
@@ -328,24 +363,65 @@ function makeNotificationsContext() {
   /// active surface based on focus state — in-app toast when focused,
   /// OS native banner when blurred. Sound is the caller's
   /// responsibility since each event uses a different chime.
+  ///
+  /// `tabId` is the tab the event originated from (resolved via
+  /// findTabForEvent in the caller). Stored on the Toast/UnreadItem
+  /// so clicking either routes the user straight to that tab.
   function alertProject(
     projectPath: string,
     title: string,
     body: string,
     kind: ToastKind,
+    tabId: string | null,
   ) {
     const here = focused() && resolver.isActiveProject(projectPath);
 
     if (!here) {
       markUnread(projectPath);
-      enqueueUnreadItem({ kind, projectPath, title, body });
+      enqueueUnreadItem({ kind, projectPath, tabId, title, body });
     }
 
     if (focused()) {
-      enqueueToast({ kind, projectPath, title, body });
+      enqueueToast({ kind, projectPath, tabId, title, body });
     } else {
       void invoke("notify_native", { title, body }).catch(() => {});
     }
+  }
+
+  /// Pure mapping: which open tab does this event correspond to?
+  /// Single source of truth for both "route toast click" and "raise
+  /// the per-tab attention flag." Returns null when sessionId is
+  /// missing (older warp builds) or no open tab matches.
+  function findTabForEvent(
+    projectPath: string,
+    sessionId: string | null,
+  ): string | null {
+    if (!sessionId) return null;
+    const tab = term.store.tabs.find(
+      (t) => t.projectPath === projectPath && t.sessionId === sessionId,
+    );
+    return tab?.id ?? null;
+  }
+
+  /// Gate for raising the amber-pulse flag on a tab. False when:
+  ///   - the project has ≤1 tab open (no ambiguity to disambiguate)
+  ///   - the user is literally looking at the tab (focused window +
+  ///     active project + this tab is its active tab; note activeTabId
+  ///     can be null on first project open, in which case the equality
+  ///     is false and we DO raise the flag — intentional).
+  /// Separate from findTabForEvent because the toast / bell routing
+  /// wants the tabId regardless of these gates (single-tab toast
+  /// click should still activate that one tab).
+  function shouldRaisePulse(projectPath: string, tabId: string): boolean {
+    const tabsInProject = term.store.tabs.filter(
+      (t) => t.projectPath === projectPath,
+    );
+    if (tabsInProject.length <= 1) return false;
+    const here =
+      focused() &&
+      resolver.isActiveProject(projectPath) &&
+      term.store.activeTabId === tabId;
+    return !here;
   }
 
   function handleComplete(payload: SessionCompletePayload) {
@@ -356,7 +432,11 @@ function makeNotificationsContext() {
       payload.preview && payload.preview.length > 0
         ? payload.preview
         : "Your turn — open Klaudio Panels.";
-    alertProject(payload.project_path, title, body, "complete");
+    const tabId = findTabForEvent(payload.project_path, payload.session_id);
+    alertProject(payload.project_path, title, body, "complete", tabId);
+    if (tabId && shouldRaisePulse(payload.project_path, tabId)) {
+      term.markTabNeedsAttention(tabId);
+    }
   }
 
   function handleAgentEvent(payload: CliAgentEvent) {
@@ -372,7 +452,11 @@ function makeNotificationsContext() {
     const preview = payload.tool_input_preview;
     const body = preview && preview.length > 0 ? `${tool}: ${preview}` : tool;
     const title = `${projectName(projectPath)} · Claude needs permission`;
-    alertProject(projectPath, title, body, "permission");
+    const tabId = findTabForEvent(projectPath, payload.session_id);
+    alertProject(projectPath, title, body, "permission", tabId);
+    if (tabId && shouldRaisePulse(projectPath, tabId)) {
+      term.markTabNeedsAttention(tabId);
+    }
   }
 
   return {

--- a/src/context/terminal.tsx
+++ b/src/context/terminal.tsx
@@ -21,6 +21,12 @@ export type TerminalTab = {
   /** epoch ms when the PTY was requested; used by the session watcher to
    *  correlate "new" tabs with their JSONL once Claude writes one. */
   spawnedAt: number;
+  /** True when this tab fired a notification while the user was looking
+   *  elsewhere. Drives the amber pulse in the tab strip. Cleared by
+   *  user-action tab activation (tab-strip click, sidebar/palette select)
+   *  or by xterm onData (the user is typing here). Project-switch does
+   *  NOT clear — see PRP 018 §4. */
+  needsAttention: boolean;
 };
 
 type TerminalStore = {
@@ -106,6 +112,7 @@ export function makeTerminalContext() {
       exitCode: null,
       error: null,
       spawnedAt: Date.now(),
+      needsAttention: false,
     };
     setStore(
       produce((s) => {
@@ -267,6 +274,22 @@ export function makeTerminalContext() {
     );
   }
 
+  // Early-return is load-bearing: clearTabAttention runs on every xterm
+  // keystroke via terminal-view.tsx's onData hook. Without the guard
+  // Solid's reactive graph dirties on every char, dragging dependent
+  // memos (tab-strip dot class, etc.) with it.
+  function markTabNeedsAttention(id: string) {
+    const tab = store.tabs.find((t) => t.id === id);
+    if (!tab || tab.needsAttention) return;
+    setStore("tabs", (t) => t.id === id, "needsAttention", true);
+  }
+
+  function clearTabAttention(id: string) {
+    const tab = store.tabs.find((t) => t.id === id);
+    if (!tab || !tab.needsAttention) return;
+    setStore("tabs", (t) => t.id === id, "needsAttention", false);
+  }
+
   onCleanup(() => {
     void closeAll();
   });
@@ -285,6 +308,8 @@ export function makeTerminalContext() {
     findTabBySessionId,
     promoteTab,
     setTabLabel,
+    markTabNeedsAttention,
+    clearTabAttention,
   };
 }
 


### PR DESCRIPTION
Closes #42.

## Summary

When a project has more than one Claude tab and one of them fires a notification (`session:complete` or warp `permission_request`) while the user is looking at a different tab, the tab strip now **pulses amber** on the offending tab. Clicking the toast or bell entry also routes straight to that tab, not just the project — the latter was a gap noticed during QA and bundled here.

PRP: `PRPs/018--tab-needs-attention-indicator.md` (v1.2).

## Architecture

- **`TerminalTab.needsAttention`** flag in the terminal store. `markTabNeedsAttention` / `clearTabAttention` early-return when the flag is already at the target value — load-bearing because `clearTabAttention` runs on every xterm `onData` keystroke.
- **`findTabForEvent`** (pure payload→tab mapping) and **`shouldRaisePulse`** (the gating: single-tab project + here-check) are split. The toast routing always uses the tabId when it resolves; the pulse gate is a separate concern (single-tab project = no ambiguity = no pulse).
- **`Toast` / `UnreadItem`** gain `tabId: string | null`. Null when sessionId is missing (older warp builds) or no open tab matches.
- **`ProjectResolver.activateTab(projectPath, tabId)`** — new resolver method implemented in `App.tsx`:
  - Same project as currently active: `clearTabAttention` + `setActiveTab` + `focusTerminal` directly.
  - Different project: `activeByProject.set` THEN `setActiveProjectPath`, so the existing project-switch effect picks the target tab as `nextActive`.
- **Clears** at every user-action activation path (the only deliberate exception is the project-switch effect, which is too coarse to clear a per-tab signal):
  - Tab-strip click → `handleActivateTab`
  - Sidebar / command palette session-click on an open tab → `handleSelectSession`
  - User typing in xterm → `onData` handler (belt-and-suspenders for the race where the flag is raised on an already-active tab)
  - Tab close → free, splicing drops the flag

## Files touched (7)

| File | Change |
| --- | --- |
| `src/context/terminal.tsx` | `needsAttention` field + two methods |
| `src/context/notifications.tsx` | `useTerminal()` hook, helpers, resolver type, handlers, toast/bell dispatch |
| `src/components/tab-strip.tsx` | `statusDotClass` takes whole tab; amber pulse beats status |
| `src/components/terminal-view.tsx` | `clearTabAttention` in xterm `onData` |
| `src/App.tsx` | `clearTabAttention` in activation handlers; resolver gains `activateTab` |
| `src/components/notification-bell.tsx` | bell click passes `item.tabId` |
| `PRPs/018--tab-needs-attention-indicator.md` | new PRP (v1.2) |

No Rust, no new Tauri commands or events, no IPC changes.

## Trade-offs

- **Null-sessionId `permission_request`** raises no per-tab flag and no toast→tab routing. A wrong-tab pulse is worse than no pulse — older warp builds (≤0.2.x) hit this; ≥0.3.0 sends sessionId reliably.
- **Cross-project toast click** activates the target tab via `activeByProject` pre-set, but focus follows `lastFocusedForProject` memory. If the user was last in shell/editor for that project, focus lands there instead of the Claude tab. The tab is visible and its pulse is cleared; accepted in v1.2 since the user's explicit ask ("toast doesn't take me to the tab") is met. One-line fix available if QA hits it: `recordTerminalFocus(tabId, projectPath)` before the project switch.
- **Single-tab projects** suppress the pulse (no ambiguity to disambiguate). Toast routing still works for the one tab.
- **No badge count, no sidebar avatar tab-level surface, no sound differentiation** — all out of scope per #42.

## Test plan

Manual, in `bun tauri dev`. Smoke tests are #1–#3; the rest cover edge cases.

### Smoke
- [ ] **Multi-tab pulse**: 2 tabs in project A, on tab 1. Tab 2 completes a session. Tab 2 dot turns amber + pulses. Project ring suppressed (focused + active).
- [ ] **Tab-strip click clears**: with pulse on tab 2, click tab 2 in the strip. Pulse clears, dot returns to running.
- [ ] **Single-tab → no pulse**: only one tab in project, it completes. No pulse anywhere.

### Toast / bell routing (v1.2)
- [ ] **Toast click — same project**: tab 1 active, tab 2 completes → toast appears → click toast → tab 2 activates, pulse clears, no project switch.
- [ ] **Toast click — cross project**: pulse on tab 2 of project A, user is in B → click toast → switches to A, tab 2 active, pulse clears.
- [ ] **Bell click**: same as above but via the notification bell entries.

### Suppression / clear paths
- [ ] **Active tab doesn't pulse**: tab 1 is active and fires the event itself → no pulse (user is looking at it).
- [ ] **Sidebar session-click clears**: pulse on tab 1 → click that session's row in Sessions sidebar → pulse clears.
- [ ] **Command palette clears**: same as above via Cmd+K.
- [ ] **Type-to-clear**: pulse on an already-active tab (rare race) → type a character → pulse clears.
- [ ] **Close clears**: pulse on tab → click X → no crash, no orphaned state.

### Project lifecycle
- [ ] **Project switch does NOT clear**: pulse on tab 1 of A → switch to B → switch back to A → tab 1 still pulses (project ring did clear).

### Prefs
- [ ] **`notifySessionComplete` off**: no toast AND no pulse on session:complete.
- [ ] **`notifyPermission` off**: no toast AND no pulse on permission_request.

### Graceful degradation
- [ ] **Null sessionId (old warp)**: toast appears, click → activates project, no tab preselected, no crash.

## Validation done by me

- `bun run typecheck` ✅
- `cd src-tauri && cargo check` ✅ (no Rust changes; sanity only)
- Manual QA: smoke #1 + #3 + tab-strip click reported by @willywg ✅
- Toast → tab routing (v1.2): pending manual verification — the typecheck confirms shapes, not visual behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)