### PR TITLE
feat(terminal): clickable bare-domain URLs + open-url diagnostics (#45)

### DIFF
--- a/PRPs/020--bare-url-links-and-open-url-diagnostics.md
+++ b/PRPs/020--bare-url-links-and-open-url-diagnostics.md
@@ -1,0 +1,160 @@
+# PRP 020: Clickable bare-domain URLs + open-url diagnostics
+
+> **Version:** 1.0
+> **Created:** 2026-05-18
+> **Status:** Draft
+> **Tracks:** [#45](https://github.com/willywg/klaudio-panels/issues/45)
+
+---
+
+## Goal
+
+Make scheme-less URLs (`app.constructai.la`, `linear.app/foo`,
+`github.com/user/repo`) clickable from any terminal surface, route
+them to the system browser via the existing opener handoff, and
+close the diagnostic gap that hides `openUrl` failures from the
+log file end-users already ship.
+
+## Why
+
+Two intertwined problems surfaced when the user reported "URLs
+don't open anymore" against v1.7.0:
+
+1. **WebLinksAddon's regex requires `https?://`.** Anything without
+   a scheme — extremely common in Claude's tool output — is invisible
+   to it. Hover does nothing, ⌘+click does nothing.
+
+2. **The file-link regex silently hijacks bare domains.**
+   `src/lib/xterm-file-links.ts` PATH_RE:
+
+   ```
+   (?:^|[\s(["'`])((?:\.{0,2}\/)?[\w.@-]+(?:\/[\w.@-]+)*\.[\w]{1,10}(?::\d+(?::\d+)?)?)
+   ```
+
+   Greedy backtracking matches `app.constructai.la` as `app.constructai`
+   + `.la` "extension". ⌘+click routes the "file" to `diffPanel.openFile`,
+   which then opens an empty preview tab for a path that doesn't exist.
+   Same story for `linear.app` → "linear" + `.app`.
+
+3. **`openUrl` failures are unobservable in prod.**
+   `src/lib/open-url.ts:11` swallows the rejection with `console.warn`.
+   `installGlobalErrorForwarding` (`src/lib/debug-log.ts:15`) only
+   forwards `window.error` + `window.unhandledrejection`, not console
+   output. So when something *does* go wrong with the opener (Tauri ACL,
+   NSWorkspace, scope), the user sees a no-op click and we have nothing
+   in `~/Library/Logs/Klaudio Panels/klaudio.log` to triage from.
+
+The fix for (1) and (2) is the same: a third link provider for
+scheme-less domains, registered before the file-link provider so the
+position-lookup gives it priority. The fix for (3) is one-liner
+diagnostics that future-proofs URL-handling regressions.
+
+## What changes
+
+### 1. New `src/lib/xterm-bare-url-links.ts`
+
+Mirrors the shape of `xterm-file-links.ts`: factory returning an
+`ILinkProvider`. Matches `(host\.)+tld[:port][/path]` where `tld` is
+in a curated allowlist (com|org|net|io|dev|app|ai|co|la|me|sh|xyz
++ common country codes — see file for the full list). Activate
+prepends `https://` and delegates to `openUrlInSystemBrowser`.
+
+Allowlist rationale: every TLD added means any file with that
+extension is hijacked into the browser. `.html` deliberately stays
+out (too common as filename). `.la` is in (Latin America country
+code, matches the user's actual context).
+
+### 2. Provider wiring in three terminal views
+
+The order matters. xterm.js resolves multi-provider clicks by
+asking each provider in registration order — the first one whose
+link covers the cursor position wins.
+
+| Surface | File | Order |
+| --- | --- | --- |
+| Claude PTY | `src/components/terminal-view.tsx` | WebLinksAddon → **bare-URL (new)** → file-link |
+| Shell PTY | `src/components/shell-terminal/shell-terminal-view.tsx` | WebLinksAddon → **bare-URL (new)** |
+| Editor PTY (nvim/helix) | `src/components/diff-panel/editor-pty-view.tsx` | WebLinksAddon → **bare-URL (new)** |
+
+The bare-URL provider goes between WebLinksAddon and file-link
+on Claude PTY for the position-lookup priority — that's what
+takes domains away from the file regex. Shell and editor only have
+WebLinks today, so the bare-URL provider is purely additive there.
+
+### 3. `src/lib/open-url.ts` — diagnostic logging
+
+Replace `console.warn` with `debugLog`:
+
+```diff
+ import { openUrl } from "@tauri-apps/plugin-opener";
++import { debugLog } from "@/lib/debug-log";
+
+ export function openUrlInSystemBrowser(
+   _event: MouseEvent,
+   uri: string,
+ ): void {
+-  void openUrl(uri).catch((err) => console.warn("openUrl failed", uri, err));
++  debugLog("open-url", `attempt ${uri}`);
++  void openUrl(uri).catch((err) => {
++    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
++    debugLog("open-url", `failed ${uri} — ${msg}`);
++  });
+ }
+```
+
+The `attempt` line is intentional — without it we can't tell whether
+the click reached the handler at all vs. the handler reached `openUrl`
+but `openUrl` failed silently after returning (e.g. NSWorkspace
+returning no-error for an unknown URL handler).
+
+## What does NOT change
+
+- WebLinksAddon stays the primary handler for `https://…` — its
+  multi-line wrap handling and trailing-punctuation trimming are
+  better than what the bare-URL provider needs to do for sceme-less
+  matches.
+- The file-link provider is untouched. The fix for the false-positive
+  comes from the registration-order change, not from tightening the
+  file regex (which would risk false negatives on real file paths).
+- `installGlobalErrorForwarding` stays scoped to errors + rejections.
+  Forwarding all `console.warn` calls would be noisy (other call sites
+  use it for non-actionable warnings); the open-url path uses
+  `debugLog` directly instead.
+
+## Risks / trade-offs
+
+- **TLD allowlist drift.** Domains under uncommon TLDs (`.museum`,
+  `.engineering`, `.dev` — wait that one's in) won't be linkified.
+  Cheap to extend — every collision goes the other way (a real file
+  ending in `.la` would lose its file-link match). Conservative on
+  purpose; we can grow the list when a real case shows up.
+- **Trailing-punctuation trimming.** The regex is liberal about path
+  characters and then strips trailing `.,;:!?)]'"\`` post-match. A
+  URL legitimately ending in one of those (rare) would be truncated
+  by one character. Same trade WebLinksAddon makes.
+- **Port ranges.** Matches `:2-5 digits`. Excludes 1-digit "ports"
+  (which clash with `:line` in `file.ts:42`) and 6+ (not valid).
+  Means `localhost:8080`-style dev URLs work; `foo.ts:42` stays a
+  file.
+
+## Verification
+
+1. `bun run typecheck` clean.
+2. In `bun tauri dev`:
+   - `https://example.com` from Claude — ⌘+click opens system browser
+     (existing WebLinksAddon path, unchanged).
+   - `app.constructai.la` — hover underlines, ⌘+click opens
+     `https://app.constructai.la` in system browser (new).
+   - `linear.app/construct-ai/issue/CAI-1292` — same, opens the
+     full URL with path (new).
+   - `src/lib/open-url.ts:11` — ⌘+click still routes to the diff
+     panel (file-link path unchanged).
+3. `tail -f ~/Library/Logs/Klaudio Panels/klaudio.log` shows
+   `[JS:open-url] attempt …` on every click; any handler failure
+   prints `[JS:open-url] failed … — <error>`.
+
+## Out of scope
+
+- Public Suffix List integration (too big for the value).
+- Detecting and offering to copy URLs that the regex doesn't match.
+- Inline preview cards for clicked URLs.

--- a/src/components/diff-panel/editor-pty-view.tsx
+++ b/src/components/diff-panel/editor-pty-view.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tauri-apps/plugin-clipboard-manager";
 import { useEditorPty } from "@/context/editor-pty";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
+import { makeBareUrlLinkProvider } from "@/lib/xterm-bare-url-links";
 import {
   recordTerminalFocus,
   registerTerminalFocus,
@@ -106,6 +107,7 @@ export function EditorPtyView(props: Props) {
   let detachData: (() => void) | undefined;
   let detachExit: (() => void) | undefined;
   let fitDebounce: number | undefined;
+  let bareUrlDisposable: { dispose: () => void } | undefined;
   let disposed = false;
 
   const encoder = new TextEncoder();
@@ -160,6 +162,12 @@ export function EditorPtyView(props: Props) {
 
     term.open(container!);
     term.unicode.activeVersion = "11";
+
+    // Bare-URL provider (see xterm-bare-url-links.ts). Editor PTYs (nvim/
+    // helix) don't have file-link match conflicts to worry about — this is
+    // purely for the convenience of clicking a bare domain that appears in
+    // an editor buffer.
+    bareUrlDisposable = term.registerLinkProvider(makeBareUrlLinkProvider(term));
 
     let webgl: WebglAddon | undefined;
     try {
@@ -316,6 +324,7 @@ export function EditorPtyView(props: Props) {
     if (fitDebounce) window.clearTimeout(fitDebounce);
     detachData?.();
     detachExit?.();
+    bareUrlDisposable?.dispose();
     try {
       term?.dispose();
     } catch (err) {

--- a/src/components/shell-terminal/shell-terminal-view.tsx
+++ b/src/components/shell-terminal/shell-terminal-view.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tauri-apps/plugin-clipboard-manager";
 import { useShellPty } from "@/context/shell-pty";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
+import { makeBareUrlLinkProvider } from "@/lib/xterm-bare-url-links";
 import {
   registerTerminalScroller,
   unregisterTerminalScroller,
@@ -62,6 +63,7 @@ export function ShellTerminalView(props: Props) {
   let detachData: (() => void) | undefined;
   let detachExit: (() => void) | undefined;
   let scrollDisposable: { dispose: () => void } | undefined;
+  let bareUrlDisposable: { dispose: () => void } | undefined;
   let fitDebounce: number | undefined;
   let disposed = false;
 
@@ -103,6 +105,11 @@ export function ShellTerminalView(props: Props) {
 
     term.open(container!);
     term.unicode.activeVersion = "11";
+
+    // Bare-URL provider lifts domains without an explicit scheme into the
+    // browser (mirrors terminal-view; see xterm-bare-url-links.ts for the
+    // collision rationale).
+    bareUrlDisposable = term.registerLinkProvider(makeBareUrlLinkProvider(term));
 
     let webgl: WebglAddon | undefined;
     try {
@@ -274,6 +281,7 @@ export function ShellTerminalView(props: Props) {
     detachData?.();
     detachExit?.();
     scrollDisposable?.dispose();
+    bareUrlDisposable?.dispose();
     unregisterTerminalScroller(props.ptyId);
     unregisterTerminalFocus(props.ptyId);
     try {

--- a/src/components/terminal-view.tsx
+++ b/src/components/terminal-view.tsx
@@ -11,6 +11,7 @@ import {
 import { useTerminal } from "@/context/terminal";
 import { useDiffPanel } from "@/context/diff-panel";
 import { makeFileLinkProvider } from "@/lib/xterm-file-links";
+import { makeBareUrlLinkProvider } from "@/lib/xterm-bare-url-links";
 import { hoverPtyId } from "@/lib/internal-drag";
 import { openUrlInSystemBrowser } from "@/lib/open-url";
 import {
@@ -66,6 +67,7 @@ export function TerminalView(props: Props) {
   let detachData: (() => void) | undefined;
   let detachExit: (() => void) | undefined;
   let linkDisposable: { dispose: () => void } | undefined;
+  let bareUrlDisposable: { dispose: () => void } | undefined;
   let scrollDisposable: { dispose: () => void } | undefined;
   let fitDebounce: number | undefined;
 
@@ -273,6 +275,11 @@ export function TerminalView(props: Props) {
       term?.writeln(`\x1b[2m\r\n[claude exited with code ${code}]\x1b[0m`);
     });
 
+    // Bare-URL provider runs BEFORE the file provider so domains like
+    // `app.constructai.la` route to the browser instead of being treated as
+    // a file with `.la` extension (file regex would otherwise greedy-match).
+    bareUrlDisposable = term.registerLinkProvider(makeBareUrlLinkProvider(term));
+
     // Cmd/Ctrl+click on `src/foo.ts` or `src/foo.ts:42` opens a preview tab.
     // Uses xterm's native link provider API so we never parse the PTY buffer
     // ourselves beyond extracting the text under the cursor.
@@ -358,6 +365,7 @@ export function TerminalView(props: Props) {
     detachData?.();
     detachExit?.();
     linkDisposable?.dispose();
+    bareUrlDisposable?.dispose();
     scrollDisposable?.dispose();
     unregisterTerminalScroller(props.id);
     unregisterTerminalFocus(props.id);

--- a/src/lib/open-url.ts
+++ b/src/lib/open-url.ts
@@ -1,4 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { debugLog } from "@/lib/debug-log";
 
 /** Shared click handler for xterm's WebLinksAddon. WebKit's default
  *  `window.open(uri, "_blank")` either no-ops or opens a second webview
@@ -8,5 +9,9 @@ export function openUrlInSystemBrowser(
   _event: MouseEvent,
   uri: string,
 ): void {
-  void openUrl(uri).catch((err) => console.warn("openUrl failed", uri, err));
+  debugLog("open-url", `attempt ${uri}`);
+  void openUrl(uri).catch((err) => {
+    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    debugLog("open-url", `failed ${uri} — ${msg}`);
+  });
 }

--- a/src/lib/xterm-bare-url-links.ts
+++ b/src/lib/xterm-bare-url-links.ts
@@ -1,0 +1,85 @@
+import type { ILink, ILinkProvider, IBufferLine, Terminal } from "@xterm/xterm";
+import { openUrlInSystemBrowser } from "@/lib/open-url";
+
+/** TLDs we treat as "this is a URL, not a file path". Kept conservative on
+ *  purpose — every entry here means a file ending in `.<tld>` will be
+ *  hijacked into the browser. The file-link provider's greedy `[\w.@-]+`
+ *  also matches `app.constructai.la` as if it were a file (`constructai.la`
+ *  is its "extension"), so registering this provider BEFORE the file
+ *  provider has the side effect of fixing that false positive — bare
+ *  domains now route to the browser instead of opening a non-existent
+ *  preview tab. */
+const TLDS = [
+  // Generic
+  "com", "org", "net", "edu", "gov", "mil", "int", "info",
+  "io", "dev", "app", "ai", "co", "me", "sh", "xyz",
+  "tech", "cloud", "site", "online", "store", "page",
+  // Country codes — Latin America first, then the common ones the user
+  // tends to see in tooling output (GitHub orgs, docs sites, etc).
+  "la", "ar", "br", "mx", "cl", "pe", "co", "ve", "uy", "py",
+  "us", "uk", "ca", "au", "nz", "de", "fr", "es", "it", "nl",
+  "se", "no", "fi", "pl", "ru", "jp", "cn", "in", "kr",
+];
+
+const HOST_PART = "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?";
+// URL path chars per RFC 3986 reserved+unreserved set, conservative —
+// trailing punctuation that's likely a sentence terminator (`.`, `,`, `;`,
+// `!`, `?`, closing brackets) gets stripped post-match instead of being
+// excluded by the regex, so we don't have to encode lookahead gymnastics.
+const PATH_CHARS = "[\\w./?#=&%~+@!*',():;-]";
+const URL_RE = new RegExp(
+  // Prefix anchor: line start or a delimiter that wouldn't appear inside a
+  // domain/path. Critically excludes `/` and `:` — that's what prevents
+  // matching `linear.app` inside an already-https URL handled by
+  // WebLinksAddon.
+  `(?:^|[\\s(\\["'\`])((?:${HOST_PART}\\.)+(?:${TLDS.join("|")})(?::\\d{2,5})?(?:/${PATH_CHARS}*)?)`,
+  "gi",
+);
+
+const TRAILING_PUNCT = /[.,;:!?)\]'"`]+$/;
+
+export function makeBareUrlLinkProvider(term: Terminal): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber, callback) {
+      const line = term.buffer.active.getLine(bufferLineNumber - 1);
+      if (!line) return callback(undefined);
+      const text = stringifyLine(line);
+      if (!text.trim()) return callback(undefined);
+
+      const links: ILink[] = [];
+      URL_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = URL_RE.exec(text)) !== null) {
+        const raw = m[1];
+        const trimmed = raw.replace(TRAILING_PUNCT, "");
+        if (!trimmed) continue;
+        const matchStart = m.index + m[0].length - raw.length;
+        const uri = `https://${trimmed}`;
+        links.push({
+          range: {
+            start: { x: matchStart + 1, y: bufferLineNumber },
+            end: { x: matchStart + trimmed.length, y: bufferLineNumber },
+          },
+          text: trimmed,
+          activate(event) {
+            openUrlInSystemBrowser(event, uri);
+          },
+        });
+      }
+
+      callback(links.length ? links : undefined);
+    },
+  };
+}
+
+function stringifyLine(line: IBufferLine): string {
+  let out = "";
+  for (let i = 0; i < line.length; i++) {
+    const cell = line.getCell(i);
+    if (!cell) continue;
+    const chars = cell.getChars();
+    if (chars) out += chars;
+    else out += " ";
+  }
+  return out.replace(/\s+$/, "");
+}


### PR DESCRIPTION
Closes #45.

## Summary

- New link provider matches scheme-less domains (`app.constructai.la`, `linear.app/foo`, `github.com/user/repo`) and routes ⌘+click to the system browser as `https://<host>/<path>`.
- Registration order fix: bare-URL provider sits between WebLinksAddon and the file-link provider in the Claude PTY, so the position lookup hands `name.tld` to the URL path instead of letting the greedy file regex match it as `name` + `.tld` "extension".
- Wired into all three terminal surfaces (Claude, shell, editor PTYs). WebLinksAddon remains the primary handler for fully-qualified URLs.
- `open-url.ts` failure path now writes to `debugLog` instead of `console.warn` — the global forwarder only catches `window.error` + `window.unhandledrejection`, so `console.warn` would never reach `~/Library/Logs/Klaudio Panels/klaudio.log`. Any future opener regression will now show up in the user-shippable log.

## Trade-offs

- TLD allowlist is curated, not exhaustive. Domains under uncommon TLDs (`.museum`, `.engineering`) won't linkify. Conservative on purpose — every entry hijacks files with that extension into the browser. Easy to extend per case.
- Trailing-punctuation trim drops one char on URLs that legitimately end in `.,;:!?)]'\"\``. Same trade WebLinksAddon makes.
- Port range is `:[2-5 digits]` so `localhost:8080` works while `file.ts:42` stays a file.

PRP: [`PRPs/020--bare-url-links-and-open-url-diagnostics.md`](https://github.com/willywg/klaudio-panels/blob/fix/bare-url-and-open-url-logging/PRPs/020--bare-url-links-and-open-url-diagnostics.md)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`https://example.com\` from Claude PTY — ⌘+click opens system browser (existing WebLinksAddon path)
- [x] \`app.constructai.la\` — hover underlines, ⌘+click opens \`https://app.constructai.la\`
- [x] \`linear.app/construct-ai/issue/CAI-1292\` — opens full URL with path
- [x] \`src/lib/open-url.ts:11\` — still routes to the diff panel (file-link path unchanged)
- [x] \`~/Library/Logs/Klaudio Panels/klaudio.log\` shows \`[JS:open-url] attempt …\` on each click

🤖 Generated with [Claude Code](https://claude.com/claude-code)