### PR TITLE
fix(sidebar): show close-project confirmation (grant dialog:allow-confirm) (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Klaudio Panels are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project uses
 semantic versioning from v0.2.0 onwards (pre-`v0.2.0` tags are PoC snapshots).
 
+## [Unreleased]
+
+### Fixed
+- **Closing a project now actually shows its confirmation dialog**
+  ([#50](https://github.com/willywg/klaudio-panels/issues/50)). The sidebar's
+  close flow called the browser-global `confirm()`, which Tauri routes to
+  `plugin:dialog|confirm` — a command our capability file never permitted, so
+  every attempt was rejected by the ACL (`dialog|confirm not allowed by ACL`)
+  and logged as an unhandled rejection. Worse, `confirm()` returns a Promise
+  under Tauri, so the synchronous `if (confirm(msg))` guard was always truthy
+  and the project closed with no prompt at all. Fixed by granting
+  `dialog:allow-confirm` and awaiting the async `confirm()` so the guard
+  genuinely gates the close. Pre-existing since 2026-04-24; unrelated to the
+  v1.8.0 avatar work.
+
 ## [1.8.0] — 2026-06-01
 
 ### Added

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "opener:default",
     "opener:allow-reveal-item-in-dir",
     "dialog:default",
+    "dialog:allow-confirm",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-image",

--- a/src/components/projects-sidebar.tsx
+++ b/src/components/projects-sidebar.tsx
@@ -1,5 +1,5 @@
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
-import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { confirm as confirmDialog, open as openDialog } from "@tauri-apps/plugin-dialog";
 import { Home, Pencil, Plus, X } from "lucide-solid";
 import {
   MAX_CUSTOM_INITIALS,
@@ -135,14 +135,18 @@ export function ProjectsSidebar(props: Props) {
     if (typeof picked === "string") props.onAdd(picked);
   }
 
-  function requestClose(path: string) {
+  async function requestClose(path: string) {
     const label = projectLabel(path);
     const openCount = props.openTabsByProject.get(path) ?? 0;
     const msg =
       openCount > 0
-        ? `Close "${label}"?\nThis will kill ${openCount} open tab(s) and remove it from the sidebar.\nIt will still be available under "Recent projects" on the home screen.`
-        : `Close "${label}"?\nIt will be removed from the sidebar. Still available under "Recent projects" on the home screen.`;
-    if (confirm(msg)) props.onCloseProject(path);
+        ? `This will kill ${openCount} open tab(s) and remove it from the sidebar.\nIt will still be available under "Recent projects" on the home screen.`
+        : `It will be removed from the sidebar. Still available under "Recent projects" on the home screen.`;
+    const ok = await confirmDialog(msg, {
+      title: `Close "${label}"?`,
+      kind: "warning",
+    });
+    if (ok) props.onCloseProject(path);
   }
 
   return (
@@ -231,7 +235,7 @@ export function ProjectsSidebar(props: Props) {
                 title="Close project (still in history)"
                 onClick={(e) => {
                   e.stopPropagation();
-                  requestClose(proj.path);
+                  void requestClose(proj.path);
                 }}
               >
                 <X size={9} strokeWidth={3} />


### PR DESCRIPTION
## What this does

Makes the sidebar's **Close project** flow actually show its confirmation dialog, and stops the per-attempt `dialog|confirm not allowed by ACL` rejection it was logging.

## Why

Closes #50. Two compounding bugs, present since 2026-04-24 (unrelated to the v1.8.0 avatar work — surfaced while triaging a "links stopped opening" report that turned out to be a stale dev server):

1. `requestClose` called the browser-global `confirm()`, which Tauri routes to `plugin:dialog|confirm`. Our `capabilities/default.json` granted `dialog:default` but **not** `dialog:allow-confirm`, so every close was rejected by the ACL and logged as an unhandled rejection.
2. Under Tauri, `confirm()` returns a **Promise** (always truthy), so the synchronous `if (confirm(msg))` guard passed regardless — the project closed with **no prompt at all**. The intended "destructive-by-accident" guard was silently a no-op.

## How to test

1. `bun tauri dev`.
2. Open a project with one or more tabs.
3. Right-click its avatar → **Close project** (or hover → ×).
4. A native confirm dialog now appears; **Cancel** keeps the project, **OK** closes it.
5. Tail `~/Library/Logs/Klaudio Panels/klaudio.log` → no more `dialog|confirm not allowed by ACL` rejections.

## Checklist

- [x] `bun run typecheck` passes
- [x] `cd src-tauri && cargo check` passes (validates the capability/ACL JSON)
- [ ] Manually smoke-tested in `bun tauri dev`
- [x] Updated `CHANGELOG.md` (entry under `[Unreleased]`)
- [ ] Updated `CLAUDE.md` / docs (not architectural — no rule change)

## Notes

- Touches 3 files: `src-tauri/capabilities/default.json` (+`dialog:allow-confirm`), `src/components/projects-sidebar.tsx` (`requestClose` → async + native `confirm()`), `CHANGELOG.md`.
- The message text moved into the dialog `title`/`kind: "warning"` so it reads as a proper warning dialog instead of a bare string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)